### PR TITLE
extlibs/SDL: disable rpath when using internal SDL

### DIFF
--- a/configure
+++ b/configure
@@ -243,6 +243,7 @@ internalise_SDL() {
     INTERNAL_SDL_TTF=true
     INTERNAL_SMPEG=true
     SDL_CONFIG=./extlib/bin/sdl-config
+    SDLOTHERCONFIG=--disable-rpath
     SMPEG_CONFIG=./extlib/bin/smpeg-config
 }
 


### PR DESCRIPTION
In Linux, this basically marks the binary with a run path of the full path of `extlib/lib/` in the directory the source code was unpacked to -- almost definitely something we do not want.