### PR TITLE
extlib/SDL: set the libtool tag as appropriate

### DIFF
--- a/extlib/src/SDL-1.2.15/Makefile.in
+++ b/extlib/src/SDL-1.2.15/Makefile.in
@@ -72,10 +72,10 @@ depend:
 include $(depend)
 
 $(objects)/$(TARGET): $(OBJECTS)
-	$(LIBTOOL) --mode=link $(CC) -o $@ $^ $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS)
+	$(LIBTOOL) --tag=CC --mode=link $(CC) -o $@ $^ $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS)
 
 $(objects)/$(SDLMAIN_TARGET): $(SDLMAIN_OBJECTS)
-	$(LIBTOOL) --mode=link $(CC) -o $@ $^ $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS) $(SDLMAIN_LDFLAGS)
+	$(LIBTOOL) --tag=CC --mode=link $(CC) -o $@ $^ $(LDFLAGS) $(EXTRA_LDFLAGS) $(LT_LDFLAGS) $(SDLMAIN_LDFLAGS)
 
 
 install: all install-bin install-hdrs install-lib install-data

--- a/extlib/src/SDL-1.2.15/build-scripts/makedep.sh
+++ b/extlib/src/SDL-1.2.15/build-scripts/makedep.sh
@@ -51,7 +51,7 @@ do  echo "Generating dependencies for $src"
     case $ext in
         c) cat >>${output}.new <<__EOF__
 
-	\$(LIBTOOL) --mode=compile \$(CC) \$(CFLAGS) \$(EXTRA_CFLAGS) -c $src  -o \$@
+	\$(LIBTOOL) --tag=CC --mode=compile \$(CC) \$(CFLAGS) \$(EXTRA_CFLAGS) -c $src  -o \$@
 
 __EOF__
         ;;
@@ -69,7 +69,7 @@ __EOF__
         ;;
         asm) cat >>${output}.new <<__EOF__
 
-	\$(LIBTOOL) --tag=CC --mode=compile \$(auxdir)/strip_fPIC.sh \$(NASM) -I\$(srcdir)/src/hermes/ $src -o \$@
+	\$(LIBTOOL) --mode=compile \$(auxdir)/strip_fPIC.sh \$(NASM) -I\$(srcdir)/src/hermes/ $src -o \$@
 
 __EOF__
         ;;


### PR DESCRIPTION
modern `libtool` seems a bit pickier about how and when these are set.