### PR TITLE
configure: generate dependency data when building with the GNU compiler suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - cc-dep-flags
   pull_request:
     branches:
       - master

--- a/Makefile.onscripter
+++ b/Makefile.onscripter
@@ -124,6 +124,7 @@ $(TDIR)nscdec$(EXESUFFIX): $(TDIR)nscdec$(OBJSUFFIX)
 $(TDIR)nscmake$(EXESUFFIX): $(TDIR)nscmake$(OBJSUFFIX)
 	$(CXX) -o $@ $(LDFLAGS) $< $(TOOL_LIBS)
 
+CLEANUP += $(ONSCRIPTER_OBJS:.o=.d)
 
 pclean:
 	-$(RM) *$(OBJSUFFIX) $(CLEANUP) $(RCCLEAN)
@@ -181,15 +182,7 @@ $(TDIR)sjis2utf16$(OBJSUFFIX): sjis2utf16.cpp
 	$(CXX) -c -o $@ $(CXXSTD) $(OSCFLAGS) $(TOOL_INCS) $(TOOL_DEFS) $<
 
 .cpp$(OBJSUFFIX):
-	$(CXX) -c $(CXXSTD) $(OSCFLAGS) $(INCS) $(DEFS) $<
-
-SarReader$(OBJSUFFIX):    $(READER_HEADER) SarReader.h
-NsaReader$(OBJSUFFIX):    $(READER_HEADER) SarReader.h NsaReader.h 
-DirectReader$(OBJSUFFIX): $(READER_HEADER) DirectReader.h
-ScriptHandler$(OBJSUFFIX): ScriptHandler.h Encoding.h
-ScriptParser$(OBJSUFFIX): $(PARSER_HEADER)
-ScriptParser_command$(OBJSUFFIX): $(PARSER_HEADER)
-Encoding$(OBJSUFFIX): Encoding.h
+	$(CXX) -c $(CXXSTD) $(OSCFLAGS) $(INCS) $(DEPFLAGS) $(DEFS) $<
 
 $(TDIR)sardec$(OBJSUFFIX): $(READER_HEADER) SarReader.h
 $(TDIR)sarconv$(OBJSUFFIX): $(READER_HEADER) SarReader.h
@@ -207,28 +200,4 @@ $(TDIR)DirectReader$(OBJSUFFIX): $(READER_HEADER) DirectReader.h
 $(TDIR)DirPaths$(OBJSUFFIX): DirPaths.h 
 $(TDIR)resize_image$(OBJSUFFIX): resize_image.h
 
-onscripter$(OBJSUFFIX): $(ONSCRIPTER_HEADER) version.h
-ONScripterLabel$(OBJSUFFIX): $(ONSCRIPTER_HEADER) graphics_common.h graphics_cpu.h graphics_resize.h
-ONScripterLabel_command$(OBJSUFFIX): $(ONSCRIPTER_HEADER) graphics_common.h graphics_resize.h version.h
-ONScripterLabel_text$(OBJSUFFIX): $(ONSCRIPTER_HEADER) Encoding.h
-ONScripterLabel_effect$(OBJSUFFIX): $(ONSCRIPTER_HEADER)
-ONScripterLabel_effect_breakup$(OBJSUFFIX): $(ONSCRIPTER_HEADER)
-ONScripterLabel_effect_cascade$(OBJSUFFIX): $(ONSCRIPTER_HEADER)
-ONScripterLabel_effect_trig$(OBJSUFFIX): $(ONSCRIPTER_HEADER)
-ONScripterLabel_event$(OBJSUFFIX): $(ONSCRIPTER_HEADER)
-ONScripterLabel_rmenu$(OBJSUFFIX): $(ONSCRIPTER_HEADER)
-ONScripterLabel_animation$(OBJSUFFIX): $(ONSCRIPTER_HEADER)
-ONScripterLabel_sound$(OBJSUFFIX): $(ONSCRIPTER_HEADER)
-ONScripterLabel_file$(OBJSUFFIX): $(ONSCRIPTER_HEADER)
-ONScripterLabel_file2$(OBJSUFFIX): $(ONSCRIPTER_HEADER)
-ONScripterLabel_image$(OBJSUFFIX): $(ONSCRIPTER_HEADER) graphics_common.h graphics_blend.h
-AnimationInfo$(OBJSUFFIX): AnimationInfo.h graphics_common.h graphics_sum.h graphics_blend.h graphics_resize.h
-FontInfo$(OBJSUFFIX): FontInfo.h Encoding.h
-DirtyRect$(OBJSUFFIX): DirtyRect.h
-DirPaths$(OBJSUFFIX): DirPaths.h
-graphics_routines$(OBJSUFFIX): graphics_common.h graphics_cpu.h graphics_sum.h graphics_blend.h graphics_resize.h resize_image.h
-resize_image$(OBJSUFFIX): resize_image.h
-Layer$(OBJSUFFIX): Layer.h AnimationInfo.h graphics_common.h graphics_sum.h
-MadWrapper$(OBJSUFFIX): MadWrapper.h
-AVIWrapper$(OBJSUFFIX): AVIWrapper.h
-LUAHandler$(OBJSUFFIX): $(ONSCRIPTER_HEADER) LUAHandler.h
+-include $(wildcard $(ONSCRIPTER_OBJS:.o=.d))

--- a/configure
+++ b/configure
@@ -364,6 +364,13 @@ then
     esac
 fi
 
+# dependency generation
+DEPFLAGS=
+case "$CXX_TMP" in
+g++* | *apple*g++*) DEPFLAGS="-MMD -MF \$(@:.o=.d) -MT \$@" ;;
+*) $echo_n "error determining compiler dependency options" >&2 ;;
+esac
+
 case "$CXX_TMP" in
 g++* | *apple*g++*) CFLAGSEXTRA=-Wall ;;
 esac
@@ -929,6 +936,7 @@ export AR      := $AR
 export RANLIB  := $RANLIB
 
 # ONScripter variables
+DEPFLAGS = $DEPFLAGS
 OSCFLAGSEXTRA = $CFLAGSEXTRA \$(OSCTMPFLAGS)
 INCS = -Iextlib/include \$(shell \$(SDL_CONFIG) --cflags)      \\
                         \$(shell $SMPEG_CONFIG --cflags)    \\
@@ -1125,7 +1133,7 @@ win32rc.o: \$(RCFILE) \$(WICONFILE)
 	sed -e "s/@Y@/$\$y/g;s/@0M@/$\$m/g;s/@M@/$\$mn/g;s/@0D@/$\$d/g;s/@D@/$\$dn/g;s%@I@%$\$i%g" \$< > \$@
 
 SDL_win32_main.o: SDL_win32_main.c
-	\$(CC) \$(CSTD) \$(OSCFLAGS) \$(INCS) \$(DEFS) -c \$< -o \$@
+	\$(CC) \$(CSTD) \$(OSCFLAGS) \$(INCS) \$(DEPFLAGS) \$(DEFS) -c \$< -o \$@
 
 \$(GNURX_DIR)/libgnurx.a:
 	\$(MAKE) -C \$(GNURX_DIR) libgnurx.a
@@ -1142,17 +1150,17 @@ then
 cat >> Makefile <<_EOF
 
 graphics_sse2.o: graphics_sse2.cpp graphics_sse2.h graphics_common.h graphics_sum.h graphics_blend.h
-	\$(CXX) \$(CXXSTD) \$(OSCFLAGS) \$(INCS) \$(DEFS) $GFX_SSE2_FLAGS -c \$< -o \$@
+	\$(CXX) \$(CXXSTD) \$(OSCFLAGS) \$(INCS) \$(DEPFLAGS) \$(DEFS) $GFX_SSE2_FLAGS -c \$< -o \$@
 
 graphics_mmx.o: graphics_mmx.cpp graphics_mmx.h graphics_common.h graphics_sum.h
-	\$(CXX) \$(CXXSTD) \$(OSCFLAGS) \$(INCS) \$(DEFS) $GFX_MMX_FLAGS -c \$< -o \$@
+	\$(CXX) \$(CXXSTD) \$(OSCFLAGS) \$(INCS) \$(DEPFLAGS) \$(DEFS) $GFX_MMX_FLAGS -c \$< -o \$@
 _EOF
 elif $USE_PPC_GFX
 then
 cat >> Makefile <<_EOF
 
 graphics_maltivec.o: graphics_maltivec.cpp graphics_maltivec.h graphics_common.h graphics_sum.h
-	\$(CXX) \$(CXXSTD) \$(OSCFLAGS) \$(INCS) \$(DEFS) $GFX_MALTIVEC_FLAGS -c \$< -o \$@
+	\$(CXX) \$(CXXSTD) \$(OSCFLAGS) \$(INCS) \$(DEPFLAGS) \$(DEFS) $GFX_MALTIVEC_FLAGS -c \$< -o \$@
 _EOF
 fi
 


### PR DESCRIPTION
No need to maintain this manually.