### PR TITLE
Fix multibyte clickstr checks

### DIFF
--- a/ScriptHandler.cpp
+++ b/ScriptHandler.cpp
@@ -1271,10 +1271,10 @@ int ScriptHandler::checkClickstr(const char *buf, bool recursive_flag)
         if (n > 1 && m == n) {
             for (int i=0; i<n; i++) {
                 if (click_buf[i] != buf[i]) goto ccs_skip;
-
-                if (!recursive_flag && checkClickstr(buf+n, true) != 0) return 0;
-                return 2;
             }
+
+            if (!recursive_flag && checkClickstr(buf + n, true) != 0) return 0;
+            return 2;
         }
 ccs_skip:
         // goto isn't *that* cursed, right? ...right?


### PR DESCRIPTION
Multibyte characters were not being properly checked against the clickstr. Fixed by moving the successful match logic to the end of the for loop.