### PR TITLE
Prioritize -f/--font arg when passed

### DIFF
--- a/ONScripterLabel.cpp
+++ b/ONScripterLabel.cpp
@@ -1288,7 +1288,10 @@ int ONScripterLabel::init()
             font_picker = -1;
             break;
     }
-    if(font_picker == -1)
+    if (default_font) {
+        font_file = default_font;
+    }
+    else if(font_picker == -1)
     {
         fprintf( stderr, "no font file detected; exiting\n" );
         return -1;


### PR DESCRIPTION
The default_font variable was previously completely ignored, even when no default font was found in any of the font paths. Added logic so that default_font is always used if the -f/--font arg was passed.