### PR TITLE
a smaller portion of a larger set of hardening fixes

### DIFF
--- a/DirPaths.cpp
+++ b/DirPaths.cpp
@@ -135,7 +135,7 @@ void DirPaths::add( const char *new_paths )
             //was an "empty path"
             //keep the "" as the first of the paths by making it a "."
             paths[0] = new char[3];
-            snprintf(paths[0], 2, "%s%c", ".", DELIMITER);
+            snprintf(paths[0], 3, "%s%c", ".", DELIMITER);
         }
     }
     const char *ptr2 = ptr1 = new_paths;

--- a/Linux_messagebox.cpp
+++ b/Linux_messagebox.cpp
@@ -302,7 +302,7 @@ getcolor(const char *colorname)
 void
 initfont(void)
 {
-	int	i, cnt;
+	int	i = 0, cnt;
 	char	*def, **lst;
 	XRectangle	ink, log;
 	XFontStruct	**fsl;

--- a/ScriptHandler.cpp
+++ b/ScriptHandler.cpp
@@ -1533,7 +1533,7 @@ int ScriptHandler::readScript( DirPaths &path )
     archive_path = &path;
 
     FILE *fp = NULL;
-    char filename[10];
+    char filename[12];
     char *file_extension = "";
     int i, n=0, encrypt_mode = 0;
     while ((fp == NULL) && (n<archive_path->get_num_paths())) {

--- a/ScriptHandler.cpp
+++ b/ScriptHandler.cpp
@@ -1534,7 +1534,7 @@ int ScriptHandler::readScript( DirPaths &path )
 
     FILE *fp = NULL;
     char filename[10];
-    char *file_extension;
+    char *file_extension = "";
     int i, n=0, encrypt_mode = 0;
     while ((fp == NULL) && (n<archive_path->get_num_paths())) {
         const char *curpath = archive_path->get_path(n);

--- a/ScriptHandler.cpp
+++ b/ScriptHandler.cpp
@@ -2288,12 +2288,13 @@ void ScriptHandler::parseStr( char **buf )
         current_variable.type |= VAR_CONST;
     }
     else{ // str alias
-        char ch, alias_buf[512];
-        int alias_buf_len = 0;
+        const char* fmt = "Undefined string alias '%s'";
+        char ch, alias_buf[MAX_ERRBUF_LEN - (strlen(fmt) - 2)]; // minus 2 accounts for the %s format specifier
+        unsigned int alias_buf_len = 0;
         bool first_flag = true;
 
         while(1){
-            if ( alias_buf_len == 511 ) break;
+            if ( alias_buf_len == sizeof(alias_buf) - 1 ) break;
             ch = **buf;
 
             if ( (ch >= 'a' && ch <= 'z') ||
@@ -2321,7 +2322,7 @@ void ScriptHandler::parseStr( char **buf )
         }
 
         if (!findStrAlias( (const char*)alias_buf, str_string_buffer )) {
-            snprintf(errbuf, MAX_ERRBUF_LEN, "Undefined string alias '%s'", alias_buf);
+            snprintf(errbuf, MAX_ERRBUF_LEN, fmt, alias_buf);
             errorAndExit(errbuf);
         }
         current_variable.type |= VAR_CONST;


### PR DESCRIPTION
The issues in this set were all discovered by compiling on Linux using `gcc` with `-fstack-protector -D_FORTIFY_SOURCE=2`.

There are more fixes to come soon, but these are probably mergeable now.