### PR TITLE
extlib: SDL_mixer: do not build playwave or playmus

### DIFF
--- a/extlib/src/SDL_mixer-1.2.12/Makefile.in
+++ b/extlib/src/SDL_mixer-1.2.12/Makefile.in
@@ -48,7 +48,7 @@ LT_RELEASE  = @LT_RELEASE@
 LT_REVISION = @LT_REVISION@
 LT_LDFLAGS  = -no-undefined -rpath $(libdir) -release $(LT_RELEASE) -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
 
-all: $(srcdir)/configure Makefile $(objects) $(objects)/$(TARGET) $(objects)/playwave$(EXE) $(objects)/playmus$(EXE)
+all: $(srcdir)/configure Makefile $(objects) $(objects)/$(TARGET)
 
 $(srcdir)/configure: $(srcdir)/configure.in
 	@echo "Warning, configure.in is out of date"


### PR DESCRIPTION
These binaries are not necessary for proper function of ONScripter-EN.