### PR TITLE
configure: skip cpuid() test on non-x86 machines

### DIFF
--- a/configure
+++ b/configure
@@ -400,6 +400,8 @@ cd .configtest
 
 if $USE_CPU_GFX
 then
+    case "x$ARCH" in
+    xx86_64|x*86)
     $echo_n "Checking for compiler cpuid support... ${nobr}"
     cat > test.cc <<-_EOF
 	#include <cpuid.h>
@@ -414,6 +416,8 @@ then
     then
         echo "     Won't compile custom graphics routines"
     fi
+    ;;
+    esac
 fi
 
 if $USE_CPU_GFX


### PR DESCRIPTION
The test is not relevant for non-x86 platforms such as PowerPC.