### PR TITLE
CI for PRs and pushes to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
     - uses: actions/upload-artifact@v3
       with:
-        name: Windows ${{matrix.arch}} Build
+        name: Linux x86-64 Build
         path: ${{ github.workspace }}/onscripter-en.Linux.x86-64.tar.gz
         
   windows:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches: [ "master", "ci" ]
   pull_request:
-    branches:
-      - master
+    branches: [ "master", "ci" ]
 
 jobs:
   linux:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe"
         sudo apt-get update -y -qq
-        sudo apt-get install libasound2-dev libpulse-dev libwebp-dev libxrandr-dev
+        sudo apt-get install libasound2-dev libpulse-dev libwebp-dev libxrandr-dev tar
     - name: configure
       env:
         CC: ${{ matrix.cc }}
@@ -38,7 +38,13 @@ jobs:
       run: |
         NCPUS=$(getconf _NPROCESSORS_ONLN)
         make -j $NCPUS VERBOSE=true
+        tar -czvf onscripter-en.Linux.x86-64.tar.gz onscripter-en README.md COPYING CHANGES
 
+    - uses: actions/upload-artifact@v3
+      with:
+        name: Windows ${{matrix.arch}} Build
+        path: ${{ github.workspace }}/onscripter-en.Linux.x86-64.tar.gz
+        
   windows:
     strategy:
       fail-fast: false
@@ -76,9 +82,16 @@ jobs:
           mingw-w64-${{matrix.env}}-zlib
           mingw-w64-${{matrix.env}}-toolchain
           make
+          zip
 
     - shell: msys2 {0}
       name: Build
       run: |
         NCPUS=$(getconf _NPROCESSORS_ONLN)
         make -f ./msys2/Makefile.Windows.MSYS2.${{matrix.arch}}.insani -j $NCPUS VERBOSE=true
+        zip onscripter-en.Windows.${{matrix.arch}}.zip onscripter-en.exe README.md COPYING CHANGES
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: Windows ${{matrix.arch}} Build
+        path: ${{ github.workspace }}/onscripter-en.Windows.${{matrix.arch}}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           mingw-w64-${{matrix.env}}-iconv
           mingw-w64-${{matrix.env}}-zlib
           mingw-w64-${{matrix.env}}-toolchain
-          mingw-w64-${{matrix.env}}-make
+          make
 
     - shell: msys2 {0}
       name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,25 @@ jobs:
       run: |
         NCPUS=$(getconf _NPROCESSORS_ONLN)
         make -j $NCPUS VERBOSE=true
-        tar -czvf onscripter-en.Linux.x86-64.tar.gz onscripter-en README.md COPYING CHANGES
+        make -j $NCPUS VERBOSE=true tools
+        tar -czvf onscripter-en.Linux.x86-64.tar.gz \
+          onscripter-en \
+          README.md \
+          COPYING \
+          CHANGES \
+          tools/ns2conv \
+          tools/nsaconv \
+          tools/sardec \
+          tools/batchconv \
+          tools/nbzdec \
+          tools/ns2make \
+          tools/nsamake \
+          tools/sarconv \
+          tools/ns2dec \
+          tools/nsadec \
+          tools/nscdec \
+          tools/nscmake \
+          tools/sarmake
 
     - uses: actions/upload-artifact@v3
       with:
@@ -89,7 +107,25 @@ jobs:
       run: |
         NCPUS=$(getconf _NPROCESSORS_ONLN)
         make -f ./msys2/Makefile.Windows.MSYS2.${{matrix.arch}}.insani -j $NCPUS VERBOSE=true
-        zip onscripter-en.Windows.${{matrix.arch}}.zip onscripter-en.exe README.md COPYING CHANGES
+        make -f ./msys2/Makefile.Windows.MSYS2.${{matrix.arch}}.insani -j $NCPUS VERBOSE=true tools
+        zip onscripter-en.Windows.${{matrix.arch}}.zip \
+          onscripter-en.exe \
+          README.md \
+          COPYING \
+          CHANGES \
+          tools/ns2conv.exe \
+          tools/nsaconv.exe \
+          tools/sardec.exe \
+          tools/batchconv.exe \
+          tools/nbzdec.exe \
+          tools/ns2make.exe \
+          tools/nsamake.exe \
+          tools/sarconv.exe \
+          tools/ns2dec.exe \
+          tools/nsadec.exe \
+          tools/nscdec.exe \
+          tools/nscmake.exe \
+          tools/sarmake.exe
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,10 +48,11 @@ jobs:
             cc: gcc
             sys: mingw64
             env: x86_64
+            arch: x86-64
           - os: windows-latest
             cc: gcc
             sys: mingw32
-            env: i686
+            arch: i686
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -79,4 +80,4 @@ jobs:
       name: Build
       run: |
         NCPUS=$(getconf _NPROCESSORS_ONLN)
-        make -f ./msys2/Makefile.Windows.MSYS2.x86-64.insani -j $NCPUS VERBOSE=true
+        make -f ./msys2/Makefile.Windows.MSYS2.${{matrix.arch}}.insani -j $NCPUS VERBOSE=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,13 @@ name: build
 
 on:
   push:
-    branches:
-      - master
+    branches: [ "master", "ci" ]
   pull_request:
     branches:
       - master
 
 jobs:
-  build:
+  linux:
     strategy:
       fail-fast: false
       matrix:
@@ -21,7 +20,6 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: install dependencies (Linux)
-      if: runner.os == 'Linux'
       run: |
         sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe"
         sudo apt-get update -y -qq
@@ -40,3 +38,43 @@ jobs:
       run: |
         NCPUS=$(getconf _NPROCESSORS_ONLN)
         make -j $NCPUS VERBOSE=true
+
+  windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            cc: gcc
+            sys: mingw64
+            env: x86_64
+          - os: windows-latest
+            cc: gcc
+            sys: mingw32
+            env: i686
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{matrix.sys}}
+        install: 
+          mingw-w64-${{matrix.env}}-SDL
+          mingw-w64-${{matrix.env}}-SDL_ttf
+          mingw-w64-${{matrix.env}}-SDL_mixer
+          mingw-w64-${{matrix.env}}-SDL_image
+          mingw-w64-${{matrix.env}}-bzip2
+          mingw-w64-${{matrix.env}}-libogg
+          mingw-w64-${{matrix.env}}-libvorbis
+          mingw-w64-${{matrix.env}}-freetype
+          mingw-w64-${{matrix.env}}-smpeg
+          mingw-w64-${{matrix.env}}-iconv
+          mingw-w64-${{matrix.env}}-zlib
+          mingw-w64-${{matrix.env}}-toolchain
+          mingw-w64-${{matrix.env}}-make
+
+    - name: build
+      run: |
+        NCPUS=$(getconf _NPROCESSORS_ONLN)
+        make -f ./msys2/Makefile.Windows.MSYS2.x86-64.insani -j $NCPUS VERBOSE=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
           - os: windows-latest
             cc: gcc
             sys: mingw32
+            env: i686
             arch: i686
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
     - uses: msys2/setup-msys2@v2
       with:
         msystem: ${{matrix.sys}}
+        update: true
         install: 
           mingw-w64-${{matrix.env}}-SDL
           mingw-w64-${{matrix.env}}-SDL_ttf
@@ -74,7 +75,8 @@ jobs:
           mingw-w64-${{matrix.env}}-toolchain
           mingw-w64-${{matrix.env}}-make
 
-    - name: build
+    - shell: msys2 {0}
+      name: Build
       run: |
         NCPUS=$(getconf _NPROCESSORS_ONLN)
         make -f ./msys2/Makefile.Windows.MSYS2.x86-64.insani -j $NCPUS VERBOSE=true

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 tools/*conv
 tools/*dec
 tools/*make
+*.exe
+onscripter.rc

--- a/tools/conv_shared.cpp
+++ b/tools/conv_shared.cpp
@@ -33,11 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-namespace jpeglib { //Mion: added namespace to avoid type conflicts
-    extern "C" {
 #include <jpeglib.h>
-    };
-}
 
 //Mion: for png image file support
 namespace libpng {
@@ -60,14 +56,14 @@ static size_t restored_length = 0;
 
 #define INPUT_BUFFER_SIZE       4096
 typedef struct {
-    struct jpeglib::jpeg_source_mgr pub;
+    struct jpeg_source_mgr pub;
 
     unsigned char *buf;
     size_t left;
 } my_source_mgr;
 
 typedef struct {
-    struct jpeglib::jpeg_destination_mgr pub;
+    struct jpeg_destination_mgr pub;
 
     unsigned char *buf;
     size_t left;
@@ -127,21 +123,21 @@ void rescaleImage( unsigned char *original_buffer, int width, int height, int by
 }
 
 
-void init_source (jpeglib::j_decompress_ptr cinfo)
+void init_source (j_decompress_ptr cinfo)
 {
 }
 
-jpeglib::boolean fill_input_buffer (jpeglib::j_decompress_ptr cinfo)
+boolean fill_input_buffer (j_decompress_ptr cinfo)
 {
     my_source_mgr *src = (my_source_mgr *)cinfo->src;
     
     src->pub.next_input_byte = src->buf;
     src->pub.bytes_in_buffer = src->left;
 
-    return jpeglib::TRUE;
+    return TRUE;
 }
 
-void skip_input_data (jpeglib::j_decompress_ptr cinfo, long num_bytes)
+void skip_input_data (j_decompress_ptr cinfo, long num_bytes)
 {
     my_source_mgr *src = (my_source_mgr *)cinfo->src;
     
@@ -149,11 +145,11 @@ void skip_input_data (jpeglib::j_decompress_ptr cinfo, long num_bytes)
     src->pub.bytes_in_buffer -= (size_t) num_bytes;
 }
 
-void term_source (jpeglib::j_decompress_ptr cinfo)
+void term_source (j_decompress_ptr cinfo)
 {
 }
 
-void init_destination (jpeglib::j_compress_ptr cinfo)
+void init_destination (j_compress_ptr cinfo)
 {
     my_destination_mgr * dest = (my_destination_mgr *) cinfo->dest;
 
@@ -161,25 +157,23 @@ void init_destination (jpeglib::j_compress_ptr cinfo)
     dest->pub.free_in_buffer = dest->left;
 }
 
-jpeglib::boolean empty_output_buffer (jpeglib::j_compress_ptr cinfo)
+boolean empty_output_buffer (j_compress_ptr cinfo)
 {
     my_destination_mgr * dest = (my_destination_mgr *) cinfo->dest;
 
     dest->pub.next_output_byte = dest->buf;
     dest->pub.free_in_buffer = dest->left;
     
-    return jpeglib::TRUE;
+    return TRUE;
 }
 
-void term_destination (jpeglib::j_compress_ptr cinfo)
+void term_destination (j_compress_ptr cinfo)
 {
 }
 
 size_t rescaleJPEGWrite( unsigned int width, unsigned int height, int byte_per_pixel, unsigned char **rescaled_buffer,
                          int quality, bool bmp2jpeg_flag, int num_of_cells )
 {
-    using namespace jpeglib;
-
     jpeg_error_mgr jerr;
     struct jpeg_compress_struct cinfo2;
     JSAMPROW row_pointer[1];
@@ -221,7 +215,7 @@ size_t rescaleJPEGWrite( unsigned int width, unsigned int height, int byte_per_p
 
     jpeg_set_defaults(&cinfo2);
     jpeg_set_quality(&cinfo2, quality, TRUE );
-    cinfo2.optimize_coding = jpeglib::TRUE;
+    cinfo2.optimize_coding = TRUE;
     //jpeg_simple_progression (&cinfo2);
     jpeg_start_compress(&cinfo2, TRUE);
 
@@ -253,8 +247,6 @@ size_t rescaleJPEGWrite( unsigned int width, unsigned int height, int byte_per_p
 size_t rescaleJPEG( unsigned char *original_buffer, size_t length,
                     unsigned char **rescaled_buffer, int quality, int num_of_cells=1 )
 {
-    using namespace jpeglib;
-
     struct jpeg_decompress_struct cinfo;
     jpeg_error_mgr jerr;
 

--- a/tools/libgnurx/Makefile
+++ b/tools/libgnurx/Makefile
@@ -38,7 +38,7 @@ libdir = ${exec_prefix}/lib
 bindir = ${exec_prefix}/bin
 mandir = ${prefix}/man
 
-CC = gcc -mthreads -mtune=pentium3
+CC = gcc -mthreads
 CFLAGS = -g -O2 -I ${srcdir}
 LDFLAGS =  -Wl,--enable-auto-image-base -Wl,--out-implib,libgnurx.dll.a
 


### PR DESCRIPTION
Adjusted the build.yml to run on both pushes to master, and PRs. It will build and upload the tools and the onscripter executable.

Currently builds and uploads for:
 - Linux x86-64
 - Windows MSYS2 mingw64 x86-64
 - Windows MSYS2 mingw32 i686

Other platforms will have to come online as we make it possible to build them again. Currently MacOS is the biggest issue.

This also includes an fix for #52, but @SeanMcG should take a look and ensure it works for their branches. Happy to remove it from this PR if it or an alternate fix goes through, I just needed it for getting tools to build across the three platforms above.