### PR TITLE
PSP Compiling and Linking Again, CI included

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,11 @@ jobs:
         export PATH="$PATH:$PSPDEV/bin"
         psp-cmake -B build .
         (cd build/ && make)
+        zip onscripter-en.PSP.zip \
+          onscripter_en \
+          README.md \
+          COPYING \
+          CHANGES
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,10 +153,10 @@ jobs:
       run: |
         curl -OL https://github.com/pspdev/pspdev/releases/latest/download/pspdev-ubuntu-latest-x86_64.tar.gz
         tar -xvf pspdev-ubuntu-latest-x86_64.tar.gz
-        export PSPDEV="$PWD/pspdev"
-        export PATH="$PATH:$PSPDEV/bin"
     - name: Build
       run: |
+        export PSPDEV="$PWD/pspdev"
+        export PATH="$PATH:$PSPDEV/bin"
         psp-cmake -B build .
         (cd build/ && make)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
         psp-cmake -B build .
         (cd build/ && make)
         zip onscripter-en.PSP.zip \
-          onscripter_en \
+          build/onscripter_en \
           README.md \
           COPYING \
           CHANGES

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           tools/nscmake \
           tools/sarmake
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Linux x86-64 Build
         path: ${{ github.workspace }}/onscripter-en.Linux.x86-64.tar.gz
@@ -126,7 +126,7 @@ jobs:
           tools/nscmake.exe \
           tools/sarmake.exe
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Windows ${{matrix.arch}} Build
         path: ${{ github.workspace }}/onscripter-en.Windows.${{matrix.arch}}.zip
@@ -165,7 +165,7 @@ jobs:
           COPYING \
           CHANGES
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: PSP Build
         path: ${{ github.workspace }}/onscripter-en.PSP.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,3 +130,37 @@ jobs:
       with:
         name: Windows ${{matrix.arch}} Build
         path: ${{ github.workspace }}/onscripter-en.Windows.${{matrix.arch}}.zip
+
+  PSP:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cc: gcc
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: install dependencies (PSP)
+      run: |
+        sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe"
+        sudo apt-get update -y -qq
+        sudo apt-get install build-essential cmake pkgconf libreadline8 libusb-0.1 libgpgme11 libarchive-tools fakeroot curl zip
+    - name: Download and install PSPDEV SDK
+      env:
+        CC: ${{ matrix.cc }}
+      run: |
+        curl -OL https://github.com/pspdev/pspdev/releases/latest/download/pspdev-ubuntu-latest-x86_64.tar.gz
+        tar -xvf pspdev-ubuntu-latest-x86_64.tar.gz
+        export PSPDEV="$PWD/pspdev"
+        export PATH="$PATH:$PSPDEV/bin"
+    - name: Build
+      run: |
+        psp-cmake -B build .
+        (cd build/ && make)
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: PSP Build
+        path: ${{ github.workspace }}/onscripter-en.PSP.zip

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tools/*dec
 tools/*make
 *.exe
 onscripter.rc
+build/

--- a/AVIWrapper.cpp
+++ b/AVIWrapper.cpp
@@ -22,7 +22,7 @@
  */
 
 #include "AVIWrapper.h"
-#include <SDL_mixer.h>
+#include <SDL/SDL_mixer.h>
 #include <audiodecoder.h>
 #include <avm_cpuinfo.h>
 #include <avm_output.h>

--- a/AVIWrapper.h
+++ b/AVIWrapper.h
@@ -24,8 +24,8 @@
 #ifndef __AVI_WRAPPER_H__
 #define __AVI_WRAPPER_H__
 
-#include <SDL.h>
-#include <SDL_thread.h>
+#include <SDL/SDL.h>
+#include <SDL/SDL_thread.h>
 #include <avifile.h>
 #include <avm_fourcc.h>
 #include <utils.h>

--- a/AnimationInfo.h
+++ b/AnimationInfo.h
@@ -30,8 +30,8 @@
 #ifndef __ANIMATION_INFO_H__
 #define __ANIMATION_INFO_H__
 
-#include <SDL.h>
-#include <SDL_image.h>
+#include <SDL/SDL.h>
+#include <SDL/SDL_image.h>
 #include <string.h>
 #include "BaseReader.h"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,56 +1,93 @@
 cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 project(onscripter_en LANGUAGES C CXX)
 
-option(ONS_USE_EXT_LIBS "Choose whether to use our own libraries or to use system packages" OFF)
+option(ONS_USE_EXT_LIBS "Choose whether to use our own libraries or to use system packages" ON)
 
-#find_package(SDL REQUIRED)
-include(FindPkgConfig)
+function(ons_create_ext_target libname libfilename)
+    add_library(${libname} STATIC IMPORTED GLOBAL)
+    set_target_properties(
+        ${libname}
+        PROPERTIES
+            IMPORTED_LOCATION 
+                ${libfilename}
+    )
+endfunction()
 
-pkg_check_modules(SDL IMPORTED_TARGET sdl)
-pkg_check_modules(SDL_image IMPORTED_TARGET sdl_image)
-pkg_check_modules(SDL_mixer IMPORTED_TARGET sdl_mixer)
-pkg_check_modules(SDL_ttf IMPORTED_TARGET sdl_ttf)
-pkg_check_modules(smpeg IMPORTED_TARGET smpeg)
-pkg_check_modules(freetype2 IMPORTED_TARGET freetype2) # freetype2?
-pkg_check_modules(mad IMPORTED_TARGET mad)
-pkg_check_modules(ogg IMPORTED_TARGET ogg)
-pkg_check_modules(zlib IMPORTED_TARGET zlib)
-pkg_check_modules(vorbis IMPORTED_TARGET vorbis)
-pkg_check_modules(vorbisfile IMPORTED_TARGET vorbisfile)
-pkg_check_modules(libpng IMPORTED_TARGET libpng)
-pkg_check_modules(libjpeg IMPORTED_TARGET libjpeg)
-pkg_check_modules(harfbuzz IMPORTED_TARGET harfbuzz)
-pkg_check_modules(bzip2 IMPORTED_TARGET bzip2)
+#if (PLATFORM_PSP)
+#
+#endif()
 
-#-lbrotlidec
-#-lbrotlicommon
-#-ltiff
-#-lwebp
-#-lgraphite2
-#-ljbig
-#-lsharpyuv
-#-lzstd
-#-ldeflate
-#-lLerc
-#-llzma
-#-liconv
-#-lrpcrt4
-#-Wl
+if(ONS_USE_EXT_LIBS)
+    include(cmake/PkgConfigWrapper.cmake)
+
+    PkgConfig_Find_Module(sdl SDL)
+    PkgConfig_Find_Module(SDL_image)
+    PkgConfig_Find_Module(SDL_mixer)
+    PkgConfig_Find_Module(SDL_ttf)
+    PkgConfig_Find_Module(freetype2) # freetype2?
+    PkgConfig_Find_Module(ogg)
+    PkgConfig_Find_Module(zlib)
+    PkgConfig_Find_Module(vorbis)
+    PkgConfig_Find_Module(vorbisfile)
+    PkgConfig_Find_Module(libpng)
+    PkgConfig_Find_Module(libjpeg)
+    PkgConfig_Find_Module(harfbuzz)
+    PkgConfig_Find_Module(bzip2)
+endif()
 
 # Windows stuff
 #-ldinput
 #-lwinmm
 #-ldxguid
 
+set(EMBED_COMMAND ${CMAKE_COMMAND} -P cmake/ResourceGenerator.cmake -- ${CMAKE_CURRENT_BINARY_DIR}/resources.cpp ons-en.ico )
+set(ADDITIONAL_EMBED_DEPENDENCIES "")
+
+add_custom_command(
+    OUTPUT resources.cpp
+    COMMAND ${EMBED_COMMAND}
+    DEPENDS ${ADDITIONAL_EMBED_DEPENDENCIES} ${CMAKE_CURRENT_SOURCE_DIR}/ons-en.ico
+    COMMENT "This command generates resources.cpp to embed files into onscripter_en, such as the icon."
+    VERBATIM
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+
+add_executable(onscripter_en)
+
+target_include_directories(onscripter_en 
+PRIVATE 
+    .
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+target_link_libraries(onscripter_en
+PUBLIC
+    PkgConfigWrapper::SDL
+    PkgConfigWrapper::SDL_image
+    PkgConfigWrapper::SDL_mixer
+    PkgConfigWrapper::SDL_ttf
+    PkgConfigWrapper::freetype2
+    PkgConfigWrapper::ogg
+    PkgConfigWrapper::zlib
+    PkgConfigWrapper::vorbis
+    PkgConfigWrapper::vorbisfile
+    PkgConfigWrapper::libpng
+    PkgConfigWrapper::libjpeg
+    PkgConfigWrapper::harfbuzz
+    PkgConfigWrapper::bzip2
+    
+    mad
+    smpeg
+)
+
 target_sources(onscripter_en
 PRIVATE
     AnimationInfo.cpp
     AnimationInfo.h
-    AVIWrapper.cpp
-    AVIWrapper.h
+#    AVIWrapper.cpp
+#    AVIWrapper.h
     BaseReader.h
-    BasicWindow.cpp
-    BasicWindow.h
     CMakeLists.txt
     DirectReader.cpp
     DirectReader.h
@@ -109,9 +146,7 @@ PRIVATE
     ScriptParser_command.cpp
     sjis2utf16.cpp
     version.h
-    Window.cpp
-    Window.h
-    winres.h
+    #winres.h
 )
 
 set(ONS_COMPILER_FLAG_STYLE "GNU")
@@ -138,40 +173,40 @@ elseif(ONS_COMPILER_FLAG_STYLE STREQUAL "MSVC")
 endif()
 
 
-if(WIN32 OR MINGW)
-    target_sources(onscripter_en
-    PRIVATE
-        onscripter.rc
-        Win32Window.cpp
-        Win32Window.h
-    )
-
-    target_link_options(onscripter_en 
-    PRIVATE
-        $<IF:$<CONFIG:DEBUG>,/SUBSYSTEM:CONSOLE,/SUBSYSTEM:WINDOWS>
-    )
-endif()
-
-if(APPLE)
-    if (IOS)
-    else() # Technically, WatchOS, TvOS, and iPadOS might fall into this to...
-        target_compile_definitions(onscripter_en PUBLIC MACOSX)
-        target_include_directories(onscripter_en PUBLIC macosx)
-    endif()
-
-
-    target_sources(onscripter_en
-    PRIVATE
-        macosx/cocoa_alertbox.h
-        macosx/cocoa_alertbox.mm
-        macosx/cocoa_alertbox_result.h
-        macosx/cocoa_bundle.h
-        macosx/cocoa_bundle.mm
-        macosx/cocoa_encoding.h
-        macosx/cocoa_encoding.mm
-        macosx/cocoa_modal_alert.h
-        macosx/cocoa_modal_alert.mm
-        macosx/cocoa_url.h
-        macosx/cocoa_url.mm
-    )
+#if(WIN32 OR MINGW)
+#    target_sources(onscripter_en
+#    PRIVATE
+#        onscripter.rc
+#        Win32Window.cpp
+#        Win32Window.h
+#    )
+#
+#    target_link_options(onscripter_en 
+#    PRIVATE
+#        $<IF:$<CONFIG:DEBUG>,/SUBSYSTEM:CONSOLE,/SUBSYSTEM:WINDOWS>
+#    )
+#endif()
+#
+#if(APPLE)
+#    if (IOS)
+#    else() # Technically, WatchOS, TvOS, and iPadOS might fall into this to...
+#        target_compile_definitions(onscripter_en PUBLIC MACOSX)
+#        target_include_directories(onscripter_en PUBLIC macosx)
+#    endif()
+#
+#
+#    target_sources(onscripter_en
+#    PRIVATE
+#        macosx/cocoa_alertbox.h
+#        macosx/cocoa_alertbox.mm
+#        macosx/cocoa_alertbox_result.h
+#        macosx/cocoa_bundle.h
+#        macosx/cocoa_bundle.mm
+#        macosx/cocoa_encoding.h
+#        macosx/cocoa_encoding.mm
+#        macosx/cocoa_modal_alert.h
+#        macosx/cocoa_modal_alert.mm
+#        macosx/cocoa_url.h
+#        macosx/cocoa_url.mm
+#    )
 #endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,177 @@
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+project(onscripter_en LANGUAGES C CXX)
+
+option(ONS_USE_EXT_LIBS "Choose whether to use our own libraries or to use system packages" OFF)
+
+#find_package(SDL REQUIRED)
+include(FindPkgConfig)
+
+pkg_check_modules(SDL IMPORTED_TARGET sdl)
+pkg_check_modules(SDL_image IMPORTED_TARGET sdl_image)
+pkg_check_modules(SDL_mixer IMPORTED_TARGET sdl_mixer)
+pkg_check_modules(SDL_ttf IMPORTED_TARGET sdl_ttf)
+pkg_check_modules(smpeg IMPORTED_TARGET smpeg)
+pkg_check_modules(freetype2 IMPORTED_TARGET freetype2) # freetype2?
+pkg_check_modules(mad IMPORTED_TARGET mad)
+pkg_check_modules(ogg IMPORTED_TARGET ogg)
+pkg_check_modules(zlib IMPORTED_TARGET zlib)
+pkg_check_modules(vorbis IMPORTED_TARGET vorbis)
+pkg_check_modules(vorbisfile IMPORTED_TARGET vorbisfile)
+pkg_check_modules(libpng IMPORTED_TARGET libpng)
+pkg_check_modules(libjpeg IMPORTED_TARGET libjpeg)
+pkg_check_modules(harfbuzz IMPORTED_TARGET harfbuzz)
+pkg_check_modules(bzip2 IMPORTED_TARGET bzip2)
+
+#-lbrotlidec
+#-lbrotlicommon
+#-ltiff
+#-lwebp
+#-lgraphite2
+#-ljbig
+#-lsharpyuv
+#-lzstd
+#-ldeflate
+#-lLerc
+#-llzma
+#-liconv
+#-lrpcrt4
+#-Wl
+
+# Windows stuff
+#-ldinput
+#-lwinmm
+#-ldxguid
+
+target_sources(onscripter_en
+PRIVATE
+    AnimationInfo.cpp
+    AnimationInfo.h
+    AVIWrapper.cpp
+    AVIWrapper.h
+    BaseReader.h
+    BasicWindow.cpp
+    BasicWindow.h
+    CMakeLists.txt
+    DirectReader.cpp
+    DirectReader.h
+    DirPaths.cpp
+    DirPaths.h
+    DirtyRect.cpp
+    DirtyRect.h
+    Encoding.cpp
+    Encoding.h
+    FontInfo.cpp
+    FontInfo.h
+    graphics_altivec.cpp
+    graphics_altivec.h
+    graphics_blend.h
+    graphics_common.h
+    graphics_cpu.h
+    graphics_mmx.cpp
+    graphics_mmx.h
+    graphics_resize.h
+    graphics_routines.cpp
+    graphics_sse2.cpp
+    graphics_sse2.h
+    graphics_sum.h
+    Layer.cpp
+    Layer.h
+    #nscriptdecode.cpp
+    NsaReader.cpp
+    NsaReader.h
+    onscripter.cpp
+    ONScripterLabel_animation.cpp
+    ONScripterLabel_command.cpp
+    ONScripterLabel_effect_breakup.cpp
+    ONScripterLabel_effect_cascade.cpp
+    ONScripterLabel_effect_trig.cpp
+    ONScripterLabel_effect.cpp
+    ONScripterLabel_event.cpp
+    ONScripterLabel_file.cpp
+    ONScripterLabel_file2.cpp
+    ONScripterLabel_image.cpp
+    ONScripterLabel_rmenu.cpp
+    ONScripterLabel_sound.cpp
+    ONScripterLabel_text.cpp
+    ONScripterLabel.cpp
+    ONScripterLabel.h
+    resize_image.cpp
+    resize_image.h
+    resources.cpp
+    resources.h
+    SarReader.cpp
+    SarReader.h
+    ScriptHandler.cpp
+    ScriptHandler.h
+    ScriptParser_command.cpp
+    ScriptParser.cpp
+    ScriptParser.h
+    ScriptParser_command.cpp
+    sjis2utf16.cpp
+    version.h
+    Window.cpp
+    Window.h
+    winres.h
+)
+
+set(ONS_COMPILER_FLAG_STYLE "GNU")
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+    set(ONS_COMPILER_FLAG_STYLE "MSVC")
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    set(ONS_COMPILER_FLAG_STYLE "MSVC")
+endif()
+
+
+if (ONS_COMPILER_FLAG_STYLE STREQUAL "GNU")
+
+elseif(ONS_COMPILER_FLAG_STYLE STREQUAL "MSVC")
+    target_compile_definitions(onscripter_en
+        PRIVATE
+        _CRT_SECURE_NO_WARNINGS
+    )
+
+    target_compile_options(onscripter_en 
+    PRIVATE
+        /W4
+    )
+endif()
+
+
+if(WIN32 OR MINGW)
+    target_sources(onscripter_en
+    PRIVATE
+        onscripter.rc
+        Win32Window.cpp
+        Win32Window.h
+    )
+
+    target_link_options(onscripter_en 
+    PRIVATE
+        $<IF:$<CONFIG:DEBUG>,/SUBSYSTEM:CONSOLE,/SUBSYSTEM:WINDOWS>
+    )
+endif()
+
+if(APPLE)
+    if (IOS)
+    else() # Technically, WatchOS, TvOS, and iPadOS might fall into this to...
+        target_compile_definitions(onscripter_en PUBLIC MACOSX)
+        target_include_directories(onscripter_en PUBLIC macosx)
+    endif()
+
+
+    target_sources(onscripter_en
+    PRIVATE
+        macosx/cocoa_alertbox.h
+        macosx/cocoa_alertbox.mm
+        macosx/cocoa_alertbox_result.h
+        macosx/cocoa_bundle.h
+        macosx/cocoa_bundle.mm
+        macosx/cocoa_encoding.h
+        macosx/cocoa_encoding.mm
+        macosx/cocoa_modal_alert.h
+        macosx/cocoa_modal_alert.mm
+        macosx/cocoa_url.h
+        macosx/cocoa_url.mm
+    )
+#endif()

--- a/DirtyRect.h
+++ b/DirtyRect.h
@@ -24,7 +24,7 @@
 #ifndef __DIRTY_RECT__
 #define __DIRTY_RECT__
 
-#include <SDL.h>
+#include <SDL/SDL.h>
 
 struct DirtyRect
 {

--- a/FontInfo.cpp
+++ b/FontInfo.cpp
@@ -30,7 +30,7 @@
 #include "FontInfo.h"
 #include "Encoding.h"
 #include <stdio.h>
-#include <SDL_ttf.h>
+#include <SDL/SDL_ttf.h>
 
 #define FI_TEST
 

--- a/FontInfo.h
+++ b/FontInfo.h
@@ -24,7 +24,7 @@
 #ifndef __FONT_INFO_H__
 #define __FONT_INFO_H__
 
-#include <SDL.h>
+#include <SDL/SDL.h>
 
 #include "Encoding.h"
 

--- a/MadWrapper.h
+++ b/MadWrapper.h
@@ -26,8 +26,8 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <SDL.h>
-#include <SDL_mixer.h>
+#include <SDL/SDL.h>
+#include <SDL/SDL_mixer.h>
 
 typedef struct _MAD_WRAPPER MAD_WRAPPER;
 

--- a/ONScripterLabel.h
+++ b/ONScripterLabel.h
@@ -46,10 +46,10 @@
 #include "DirPaths.h"
 #include "ScriptParser.h"
 #include "DirtyRect.h"
-#include <SDL.h>
-#include <SDL_image.h>
-#include <SDL_ttf.h>
-#include <SDL_mixer.h>
+#include <SDL/SDL.h>
+#include <SDL/SDL_image.h>
+#include <SDL/SDL_ttf.h>
+#include <SDL/SDL_mixer.h>
 
 #ifdef MP3_MAD
 #include "MadWrapper.h"

--- a/ONScripterLabel_file.cpp
+++ b/ONScripterLabel_file.cpp
@@ -147,10 +147,10 @@ void ONScripterLabel::searchSaveFile( SaveFileInfo &save_file_info, int no )
         return;
     }
 
-    save_file_info.month  = buf.st_mtime.month;
-    save_file_info.day    = buf.st_mtime.day;
-    save_file_info.hour   = buf.st_mtime.hour;
-    save_file_info.minute = buf.st_mtime.minute;
+    save_file_info.month  = buf.sce_st_mtime.month;
+    save_file_info.day    = buf.sce_st_mtime.day;
+    save_file_info.hour   = buf.sce_st_mtime.hour;
+    save_file_info.minute = buf.sce_st_mtime.minute;
 #else
     sprintf( file_name, "save%d.dat", no );
     FILE *fp;

--- a/ScriptParser.h
+++ b/ScriptParser.h
@@ -46,7 +46,7 @@
 #include <math.h>
 #include <time.h>
 
-#include <SDL_mixer.h>
+#include <SDL/SDL_mixer.h>
 #include "DirPaths.h"
 #include "ScriptHandler.h"
 #include "NsaReader.h"
@@ -78,8 +78,8 @@
 #define DEFAULT_LOOKBACK_NAME3 "doffcur.bmp"
 
 // Mion: kinsoku
-#define DEFAULT_START_KINSOKU "vxjnpABCDEHIRSTUX["
-#define DEFAULT_END_KINSOKU   "uwimo"
+#define DEFAULT_START_KINSOKU "ï¿½vï¿½xï¿½jï¿½nï¿½pï¿½Aï¿½Bï¿½Cï¿½Dï¿½Eï¿½Hï¿½Iï¿½Rï¿½Sï¿½Tï¿½Uï¿½Xï¿½["
+#define DEFAULT_END_KINSOKU   "ï¿½uï¿½wï¿½iï¿½mï¿½o"
 
 typedef unsigned char uchar3[3];
 

--- a/cmake/PkgConfigWrapper.cmake
+++ b/cmake/PkgConfigWrapper.cmake
@@ -1,0 +1,64 @@
+find_package(PkgConfig)
+
+function(PkgConfig_Find_Module module_name)
+    pkg_check_modules(${module_name}_TO_FIND REQUIRED ${module_name})
+
+    if (${ARGC} EQUAL "1")
+        set(target_name ${module_name})
+    elseif(${ARGC} EQUAL "2")
+        set(target_name ${ARGV1})
+    endif()
+
+    list(LENGTH ${module_name}_TO_FIND_LIBRARY_DIRS include_dir_length)
+
+    if (${include_dir_length} GREATER 2)
+        message(STATUS "We've encountered a pkg-config library (${module_name}) with more than a debug and release include directory.")
+        #foreach(dir ${${module_name}_TO_FIND_LIBRARY_DIRS})
+        #    message(STATUS "\t${dir}")
+        #endforeach()
+    endif()
+
+    # STATIC should be variable here, should detect it somehow.
+    add_library(PkgConfigWrapper::${target_name} INTERFACE IMPORTED)
+    
+
+    set(${module_name}_TO_FIND_LIBRARY_DIRS_DEBUG ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib)
+    set(${module_name}_TO_FIND_LIBRARY_DIRS_RELEASE ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib)
+
+    foreach(library ${${module_name}_TO_FIND_LIBRARIES})
+        if (TARGET PkgConfigWrapperSubLib::${library})
+            continue()
+        endif()
+
+        # Get the release library
+        unset(${module_name}_TO_FIND_${library}_RELEASE_LIBRARY_FOUND)
+        find_library(${module_name}_TO_FIND_${library}_RELEASE_LIBRARY_FOUND NAMES ${library} PATHS ${${module_name}_TO_FIND_LIBRARY_DIRS_RELEASE} NO_CACHE NO_DEFAULT_PATH)
+
+        # Get the debug library
+        unset(${module_name}_TO_FIND_${library}_DEBUG_LIBRARY_FOUND)
+        find_library(${module_name}_TO_FIND_${library}_DEBUG_LIBRARY_FOUND NAMES ${library} PATHS ${${module_name}_TO_FIND_LIBRARY_DIRS_DEBUG} NO_CACHE NO_DEFAULT_PATH)
+        
+        if (${${module_name}_TO_FIND_${library}_RELEASE_LIBRARY_FOUND} STREQUAL ${module_name}_TO_FIND_${library}_RELEASE_LIBRARY_FOUND-NOTFOUND)
+            message(STATUS "Giving up and just linking ${library}")
+            set_property(TARGET PkgConfigWrapper::${target_name} APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${library})
+        else()
+            add_library(PkgConfigWrapperSubLib::${library} UNKNOWN IMPORTED)
+            set_target_properties(PkgConfigWrapperSubLib::${library} PROPERTIES
+                IMPORTED_LOCATION ${${module_name}_TO_FIND_${library}_RELEASE_LIBRARY_FOUND}
+                IMPORTED_LOCATION_DEBUG ${${module_name}_TO_FIND_${library}_DEBUG_LIBRARY_FOUND}
+            )
+        
+            set_property(TARGET PkgConfigWrapper::${target_name} APPEND PROPERTY INTERFACE_LINK_LIBRARIES PkgConfigWrapperSubLib::${library})
+        endif()
+    endforeach()
+
+    foreach(include_dir ${${module_name}_TO_FIND_INCLUDE_DIRS})
+        if (EXISTS ${include_dir})
+            set_property(TARGET PkgConfigWrapper::${target_name} APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${include_dir})
+        endif()
+    endforeach()
+    
+    foreach(cflag ${${module_name}_TO_FIND_CFLAGS_OTHER})
+        set_property(TARGET PkgConfigWrapper::${target_name} APPEND PROPERTY INTERFACE_COMPILE_OPTIONS ${cflag})
+    endforeach()
+endfunction()

--- a/cmake/ResourceGenerator.cmake
+++ b/cmake/ResourceGenerator.cmake
@@ -1,0 +1,51 @@
+message(STATUS "Arg Count: ${CMAKE_ARGC}")
+
+set(i 0)
+while(NOT ${i} STREQUAL ${CMAKE_ARGC})
+    message(STATUS "Arg${i} ${CMAKE_ARGV${i}}")
+    math(EXPR i "${i}+1")
+endwhile()
+
+message(STATUS "File name to generate ${CMAKE_ARGV4}")
+
+set(generatedFile "// Generated file - do not edit\n\n#include <string.h>\n#include \"resources.h\"\n\n")
+
+set(arg_counter 5)
+set(file_counter 0)
+while(NOT ${arg_counter} STREQUAL ${CMAKE_ARGC})
+    message(STATUS "File name to blit ${CMAKE_ARGV${arg_counter}}")
+
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/${CMAKE_ARGV${arg_counter}} currentFileData HEX)
+    
+    string(REPEAT "[0-9a-f]" 32 column_pattern)
+    string(REGEX REPLACE "(${column_pattern})" "\\1\n\t" content "${currentFileData}")
+    string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\1, " hexData ${content})
+
+    set(generatedFile "${generatedFile}\nstatic const unsigned char resource_${file_counter}_buffer[] = {\n\t${hexData}\n}\;\n")
+    message(STATUS "${CMAKE_ARGV${arg_counter}}")
+    math(EXPR arg_counter "${arg_counter}+1")
+    math(EXPR file_counter "${file_counter}+1")
+endwhile()
+
+set(generatedFile "${generatedFile}\nstatic const InternalResource resource_list[] = {")
+set(arg_counter 5)
+set(file_counter 0)
+while(NOT ${arg_counter} STREQUAL ${CMAKE_ARGC})
+    file(SIZE ${CMAKE_CURRENT_SOURCE_DIR}/${CMAKE_ARGV${arg_counter}} currentFileSize)
+    set(generatedFile "${generatedFile}\n\t{ \"${CMAKE_ARGV${arg_counter}}\", resource_${file_counter}_buffer, ${currentFileSize} },")
+    
+    message(STATUS "${CMAKE_ARGV${arg_counter}}")
+    math(EXPR arg_counter "${arg_counter}+1")
+    math(EXPR file_counter "${file_counter}+1")
+endwhile()
+
+set(generatedFile "${generatedFile}\n\t{ 0, 0, 0 }\n}\;\n
+const InternalResource* getResource(const char* filename)
+{
+	for (const InternalResource* rv = resource_list\; rv->buffer\; ++rv) {
+		if (strcmp(rv->filename, filename) == 0) return rv\;
+	}
+	return NULL\;
+}\n\n")
+
+file(WRITE ${CMAKE_ARGV4} ${generatedFile})

--- a/graphics_blend.h
+++ b/graphics_blend.h
@@ -26,7 +26,7 @@
 #ifndef __GRAPHICS_BLEND_H__
 #define __GRAPHICS_BLEND_H__
 
-#include <SDL.h>
+#include <SDL/SDL.h>
 #include "graphics_common.h"
 
 // Incorporates code originally from AnimationInfo.cpp & ONScripterLabel_image.cpp,

--- a/graphics_resize.h
+++ b/graphics_resize.h
@@ -25,7 +25,7 @@
 #ifndef __GRAPHICS_RESIZE_H__
 #define __GRAPHICS_RESIZE_H__
 
-#include <SDL.h>
+#include <SDL/SDL.h>
 #include "graphics_common.h"
 
 namespace ons_gfx {


### PR DESCRIPTION
I know there's been concern about breaking previous in-source ports, so before I suggest more interesting changes I wanted to get some of them working again. PSP is a first step towards Mac, since they'll both be able to use CMake (but PSP can use system libs, which is far less safe on Mac).

This isn't fully tested yet, it's just the first step. I'll need to look in how to actually package the executable with a game and test it out. Ideally we could have the CI run a simple script and ensure it doesn't crash,, but we're not there yet.

The CMake is still messy, please excuse it, I'll be continuing to iterate on it as time goes on so it can target more platforms.