### PR TITLE
add some unit tests using GTest and GMock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: install dependencies (Linux)
       run: |
@@ -38,6 +40,7 @@ jobs:
         NCPUS=$(getconf _NPROCESSORS_ONLN)
         make -j $NCPUS VERBOSE=true
         make -j $NCPUS VERBOSE=true tools
+        make check
         tar -czvf onscripter-en.Linux.x86-64.tar.gz \
           onscripter-en \
           README.md \
@@ -80,6 +83,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
     
     - uses: msys2/setup-msys2@v2
       with:
@@ -98,6 +103,8 @@ jobs:
           mingw-w64-${{matrix.env}}-iconv
           mingw-w64-${{matrix.env}}-zlib
           mingw-w64-${{matrix.env}}-toolchain
+          mingw-w64-${{matrix.env}}-autotools
+          autotools
           make
           zip
 
@@ -107,6 +114,7 @@ jobs:
         NCPUS=$(getconf _NPROCESSORS_ONLN)
         make -f ./msys2/Makefile.Windows.MSYS2.${{matrix.arch}}.insani -j $NCPUS VERBOSE=true
         make -f ./msys2/Makefile.Windows.MSYS2.${{matrix.arch}}.insani -j $NCPUS VERBOSE=true tools
+        make -f ./msys2/Makefile.Windows.MSYS2.${{matrix.arch}}.insani check
         zip onscripter-en.Windows.${{matrix.arch}}.zip \
           onscripter-en.exe \
           README.md \

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tools/*dec
 tools/*make
 *.exe
 onscripter.rc
+test/googletest
+test/test_*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/googletest"]
+	path = test/googletest
+	url = https://github.com/google/googletest.git

--- a/Makefile.extlibs
+++ b/Makefile.extlibs
@@ -216,11 +216,17 @@ clean_smpeg:
 dclean_smpeg: clean_smpeg
 	@-if [ -f $(SMPGSRC)/Makefile ]; then $(MAKE) -C $(SMPGSRC) distclean; fi
 
+ifdef DEBUG
+	SMPEG_DEBUG=
+else
+	SMPEG_DEBUG=debug
+endif
+
 $(SMPGSRC)/Makefile: $(if $(INTERNAL_SDL),$(EB)/sdl-config)
 	@echo Configuring internal smpeg...
 	@cd $(SMPGSRC) && \
 	./configure --prefix="$(LPREFIX)" $(OTHERCONFIG) \
-	    $(addprefix --disable-,shared gtk-player opengl-player debug) \
+	    $(addprefix --disable-,shared gtk-player opengl-player $(SMPEG_DEBUG)) \
 	    $(REDIR)
 	@sed -i '/hufftable\.lo: audio\/hufftable\.cpp/{n;s/$$(CXXFLAGS)/$$(CXXFLAGS) -Wno-narrowing/}' $(SMPGSRC)/Makefile # Fix for unnecessary error -Galladite 2023-2-9
 

--- a/Makefile.unittest
+++ b/Makefile.unittest
@@ -1,0 +1,14 @@
+# -*- makefile-gmake -*-
+#
+# Makefile.unittest - General makefile rules for ONScripter's unit tests
+#
+
+#ifdef COVERAGE
+OSCFLAGS += -fprofile-arcs -ftest-coverage
+LDFLAGS += -fprofile-arcs -ftest-coverage
+CLEANUP += $(ONSCRIPTER_OBJS:.o=.gcda) $(ONSCRIPTER_OBJS:.o=.gcno)
+#endif
+
+.PHONY: check
+check: $(TARGET)$(EXESUFFIX) test/Makefile
+	$(MAKE) -C test CXX="$(CXX)" OBJSUFFIX="$(OBJSUFFIX)" EXESUFFIX="$(EXESUFFIX)" LIBSUFFIX="$(LIBSUFFIX)" COVERAGE=$(COVERAGE)

--- a/configure
+++ b/configure
@@ -1124,6 +1124,7 @@ cat >> Makefile <<_EOF
 
 include Makefile.extlibs
 include Makefile.onscripter
+include Makefile.unittest
 
 .PHONY: libtoolreplace
 libtoolreplace: | \$(EB)

--- a/msys2/Makefile.Windows.MSYS2.i686.insani
+++ b/msys2/Makefile.Windows.MSYS2.i686.insani
@@ -109,6 +109,7 @@ RC_HDRS =
 
 #include Makefile.extlibs
 include Makefile.onscripter
+include Makefile.unittest
 
 .PHONY: libtoolreplace
 libtoolreplace:

--- a/msys2/Makefile.Windows.MSYS2.x86-64.insani
+++ b/msys2/Makefile.Windows.MSYS2.x86-64.insani
@@ -110,6 +110,7 @@ RC_HDRS =
 
 #include Makefile.extlibs
 include Makefile.onscripter
+include Makefile.unittest
 
 .PHONY: libtoolreplace
 libtoolreplace:

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,55 @@
+# -*- makefile-gmake -*-
+#
+# test/Makefile
+#
+
+TOPSRC := $(abspath ..)
+OBJSUFFIX ?= .o
+LIBSUFFIX ?= .a
+
+CXX ?= g++
+CXXSTD = -std=c++98
+CXXFLAGS = -g -Wall -Wextra -DGTEST_LANG_CXX11=0 -pthread
+
+ifeq ($(COVERAGE),1)
+CXXFLAGS += -fprofile-arcs -ftest-coverage -O0
+endif
+
+GTEST_DIR=googletest/googletest
+GTEST_INCDIR=$(GTEST_DIR)/include
+GMOCK_DIR=googletest/googlemock
+GMOCK_INCDIR=$(GMOCK_DIR)/include
+
+all: test
+
+include Makefile.testlibs
+
+.cpp$(OBJSUFFIX):
+	$(CXX) $(CXXSTD) -isystem $(GTEST_INCDIR) -I$(GTEST_DIR) $(CXXFLAGS) -c $< -o $@
+
+.cc$(OBJSUFFIX):
+	$(CXX) $(CXXSTD) -isystem $(GTEST_INCDIR) -I$(GTEST_DIR) $(CXXFLAGS) -c $< -o $@
+
+test_%$(EXESUFFIX): test_%.cpp $(TOPSRC)/%.cpp libgtest$(LIBSUFFIX)
+	@$(CXX) $(CXXSTD) -isystem $(GTEST_INCDIR) -I$(TOPSRC) $(CXXFLAGS) $^ -o $@
+	./$@
+
+test_Encoding$(EXESUFFIX): test_Encoding.cpp $(TOPSRC)/Encoding.cpp $(TOPSRC)/sjis2utf16.cpp libgtest$(LIBSUFFIX)
+	@$(CXX) $(CXXSTD) -isystem $(GTEST_INCDIR) -I$(TOPSRC) $(CXXFLAGS) $^ -o $@
+	./$@
+TESTEXE := test_Encoding$(EXESUFFIX)
+
+test: $(TESTEXE)
+
+#CLEAN_PKG += googletest
+
+clean::
+	$(RM) $(CLEAN_OBJ) $(TESTEXE)
+	$(RM) -R $(CLEAN_PKG)
+
+#distclean:: clean
+#	$(RM) $(DISTCLEAN_PKG)
+
+.PHONY: all clean test $(TESTEXE)
+
+.DELETE_ON_ERROR:

--- a/test/Makefile.testlibs
+++ b/test/Makefile.testlibs
@@ -1,0 +1,22 @@
+gtest-all$(OBJSUFFIX): $(GTEST_DIR)/src/gtest-all.cc
+	$(CXX) $(CXXSTD) -isystem $(GTEST_INCDIR) -I$(GTEST_DIR) $(CXXFLAGS) -c $< -o $@
+gtest_main$(OBJSUFFIX): $(GTEST_DIR)/src/gtest_main.cc
+	$(CXX) $(CXXSTD) -isystem $(GTEST_INCDIR) -I$(GTEST_DIR) $(CXXFLAGS) -c $< -o $@
+
+libgtest$(LIBSUFFIX): gtest-all$(OBJSUFFIX) gtest_main$(OBJSUFFIX)
+	$(AR) -rv $@ $^
+
+gmock-all$(OBJSUFFIX): $(GMOCK_DIR)/src/gmock-all.cc
+	$(CXX) $(CXXSTD) -isystem $(GMOCK_INCDIR) -isystem $(GTEST_INCDIR) -I$(GMOCK_DIR) -I$(GTEST_DIR) $(CXXFLAGS) -c $< -o $@
+gmock_main$(OBJSUFFIX): $(GMOCK_DIR)/src/gmock_main.cc
+	$(CXX) $(CXXSTD) -isystem $(GMOCK_INCDIR) -isystem $(GTEST_INCDIR) -I$(GMOCK_DIR) -I$(GTEST_DIR) $(CXXFLAGS) -c $< -o $@
+
+libgmock$(LIBSUFFIX): gmock-all$(OBJSUFFIX) gmock_main$(OBJSUFFIX)
+	$(AR) -rv $@ $^
+
+$(GTEST_DIR)/src/gtest-all.cc: googletest
+$(GTEST_DIR)/src/gtest_main.cc: googletest
+$(GMOCK_DIR)/src/gmock-all.cc: googletest
+$(GMOCK_DIR)/src/gmock_main.cc: googletest
+
+CLEAN_OBJ += libgtest.a gtest_main.o gtest-all.o libgmock.a gmock_main.o gmock-all.o

--- a/test/test_Encoding.cpp
+++ b/test/test_Encoding.cpp
@@ -1,0 +1,89 @@
+#include <cstring>
+
+#include "Encoding.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST (TestEncoding, DefaultConstructor) {
+  Encoding enc;
+  EXPECT_EQ(Encoding::CODE_CP932, enc.getEncoding());
+}
+
+TEST (TestEncoding, getEncoding) {
+  Encoding enc;
+  int code = enc.getEncoding();
+  EXPECT_EQ(Encoding::CODE_CP932, code);
+}
+
+TEST (TestEncoding, setEncoding) {
+  Encoding enc;
+  enc.setEncoding(Encoding::CODE_UTF8);
+  EXPECT_EQ(Encoding::CODE_UTF8, enc.getEncoding());
+}
+
+TEST (TestEncoding, getTextMarker) {
+  Encoding enc;
+  char marker;
+
+  enc.setEncoding(Encoding::CODE_UTF8);
+  marker = enc.getTextMarker();
+  EXPECT_TRUE(marker);
+  EXPECT_EQ('^', marker);
+}
+
+TEST (TestEncoding, getTextMarkerWithCP932) {
+  Encoding enc;
+  char marker;
+
+  enc.setEncoding(Encoding::CODE_CP932);
+  marker = enc.getTextMarker();
+  EXPECT_TRUE(marker);
+  EXPECT_EQ('`', marker);
+}
+
+TEST (TestEncoding, getBytes) {
+  Encoding enc;
+  int bytes = -1;
+
+  bytes = enc.getBytes('a', Encoding::CODE_UTF8);
+  EXPECT_EQ(1, bytes);
+  bytes = enc.getBytes(0xC0, Encoding::CODE_UTF8);
+  EXPECT_EQ(2, bytes);
+  bytes = enc.getBytes(0xE0, Encoding::CODE_UTF8);
+  EXPECT_EQ(3, bytes);
+  bytes = enc.getBytes(0xF0, Encoding::CODE_UTF8);
+  EXPECT_EQ(4, bytes);
+}
+
+TEST (TestEncoding, getNum) {
+  const char* buf = "abc123";
+  Encoding enc;
+  int num = enc.getNum((const unsigned char*)buf);
+  EXPECT_EQ(6, num);
+}
+
+TEST (TestEncoding, getUTF16) {
+  Encoding enc;
+  std::string text("abc123");
+  unsigned short unicode = enc.getUTF16(text.c_str(), Encoding::CODE_UTF8);
+  EXPECT_EQ(97, unicode);
+}
+
+TEST (TestEncoding, getUTF16WithCP932) {
+  Encoding enc;
+  char* str = new char[8];
+  ::strncpy(str, "abc123", 6);
+  unsigned short unicode = enc.getUTF16(str, Encoding::CODE_CP932);
+  EXPECT_EQ(97, unicode);
+  delete[] str;
+  str = new char[2];
+  str[0] = 0xA0;
+  str[1] = 0x0;
+  unicode = enc.getUTF16(str, Encoding::CODE_CP932);
+  EXPECT_EQ(65376, unicode);
+  delete[] str;
+}
+
+} // namespace


### PR DESCRIPTION
For now, apart from adding a few tests for 'Encoding', this just sets up the 2 dependencies to be downloaded, checksummed, built and installed.

The tests can be run with `make check`.

Additionally, a code coverage report can be generated by building all targets with `COVERAGE=1` and running the tests, then feeding the result to `gcov`.