### PR TITLE
Fixing the 64-bit build for Windows 7

### DIFF
--- a/msys2/Makefile.Windows.MSYS2.x86-64.insani
+++ b/msys2/Makefile.Windows.MSYS2.x86-64.insani
@@ -72,6 +72,7 @@ LIBS = -static -Wl,--start-group \
        -lSDL_image -ljpeg -lpng -lz \
        -lSDL_mixer -logg -lvorbis -lvorbisfile \
        -lbrotlidec -lbrotlicommon -lharfbuzz -ltiff -lwebp -lmad -lgraphite2 -ljbig -lsharpyuv -lzstd -ldeflate -lLerc -llzma -liconv -ldinput -lwinmm -ldxguid -lrpcrt4 \
+       -lusp10 \
        -lbz2 -Wl,--end-group
 
 # Remove -DUSE_MESSAGEBOX if you don't want Windows dialog boxes


### PR DESCRIPTION
When running the 64-bit build on Windows 7 you'll hit this:
![image](https://github.com/user-attachments/assets/44cb6922-340e-41ee-bec9-fba3cb022847)

The docs for the function illuminate the need to link usp10.lib for Windows prior to 10. Turns out the 32-bit build has had the fix this whole time, so I copy/pasted the line and it worked straight away.