### PR TITLE
Strip debug info from Windows builds.

### DIFF
--- a/msys2/Makefile.Windows.MSYS2.i686.insani
+++ b/msys2/Makefile.Windows.MSYS2.i686.insani
@@ -64,7 +64,7 @@ TOOL_LIBS = -Wl,--start-group \
             -ljpeg -lpng -lz \
             -L$(GNURX_DIR) -lgnurx \
             -lbz2 -Wl,--end-group
-LIBS = -static -Wl,--start-group \
+LIBS = -static -s -Wl,--start-group \
        $(shell $(SDL_CONFIG) --static-libs) \
        -lSDL_ttf \
        $(shell smpeg-config --libs) $(shell pkg-config freetype2 --libs) \

--- a/msys2/Makefile.Windows.MSYS2.x86-64.insani
+++ b/msys2/Makefile.Windows.MSYS2.x86-64.insani
@@ -65,7 +65,7 @@ TOOL_LIBS = -Wl,--start-group \
             -ljpeg -lpng -lz \
             -L$(GNURX_DIR) -lgnurx \
             -lbz2 -Wl,--end-group
-LIBS = -static -Wl,--start-group \
+LIBS = -static -s -Wl,--start-group \
        $(shell $(SDL_CONFIG) --static-libs) \
        -lSDL_ttf \
        $(shell smpeg-config --libs) $(shell pkg-config freetype2 --libs) \


### PR DESCRIPTION
Seems that mingw doesn't strip binaries by default. I kind of assumed this was already being done but @SeanMcG asked and after some testing it turns out it doesn't. A nearly 3.5MB win here in binary size..