### PR TITLE
extlibs/png: ensure to use the internal copy of zlib

### DIFF
--- a/Makefile.extlibs
+++ b/Makefile.extlibs
@@ -122,12 +122,13 @@ internal_jpeg = $(EL)/libjpeg$(LIBSUFFIX)
 $(PNGSRC)/Makefile: $(EL)/libz$(LIBSUFFIX)
 	@echo Configuring internal libpng...
 	@cd $(PNGSRC) && \
-	./configure --prefix="$(LPREFIX)" --disable-shared --disable-dependency-tracking $(OTHERCONFIG) $(REDIR)
+	./configure --prefix="$(LPREFIX)" --disable-shared --disable-dependency-tracking --with-zlib-prefix="$(LPREFIX)" $(OTHERCONFIG) $(REDIR)
 
 $(EL)/libpng$(LIBSUFFIX): $(PNGSRC)/Makefile | $(EL)
 	@echo Building internal libpng...
 	@$(MAKE) -C $(PNGSRC) $(REDSO)
 	@$(MAKE) -C $(PNGSRC) install $(REDSO)
+	@sed -i '/^Requires.*:/s/ zlib//' $(EL)/pkgconfig/libpng*.pc
 
 $(EL)/libz$(LIBSUFFIX): | $(EL)
 	@echo Building internal zlib...


### PR DESCRIPTION
zlib-1.2.3 does not include a `pkgconfig` script, so we have to force this here in order to not use the system libraries.