### PR TITLE
Another Pass at fixing Warnings 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           tools/nscmake \
           tools/sarmake
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Linux x86-64 Build
         path: ${{ github.workspace }}/onscripter-en.Linux.x86-64.tar.gz
@@ -134,7 +134,7 @@ jobs:
           tools/nscmake.exe \
           tools/sarmake.exe
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Windows ${{matrix.arch}} Build
         path: ${{ github.workspace }}/onscripter-en.Windows.${{matrix.arch}}.zip

--- a/BaseReader.h
+++ b/BaseReader.h
@@ -29,6 +29,7 @@
 #ifndef __BASE_READER_H__
 #define __BASE_READER_H__
 
+#include <cstring>
 #include <stdio.h>
 
 #ifndef SEEK_END
@@ -68,7 +69,9 @@ struct BaseReader
         FileInfo()
         : compression_type(NO_COMPRESSION),
           offset(0), length(0), original_length(0)
-        {}
+        {
+            memset(&name, 0, sizeof(name));
+        }
     };
 
     struct ArchiveInfo{

--- a/DirectReader.cpp
+++ b/DirectReader.cpp
@@ -317,7 +317,7 @@ unsigned long DirectReader::swapLong( unsigned long ch )
            ((ch & 0x0000ff00) << 8) | ((ch & 0x000000ff) << 24);
 }
 
-int DirectReader::open( const char *name )
+int DirectReader::open( const char* /*name*/ )
 {
     return 0;
 }
@@ -365,10 +365,9 @@ int DirectReader::getRegisteredCompressionType( const char *file_name )
     return NO_COMPRESSION;
 }
     
-struct DirectReader::FileInfo DirectReader::getFileByIndex( unsigned int index )
+struct DirectReader::FileInfo DirectReader::getFileByIndex( unsigned int /*index*/ )
 {
     DirectReader::FileInfo fi;
-    memset(&fi, 0, sizeof(DirectReader::FileInfo));
     return fi;
 }
 
@@ -385,6 +384,7 @@ FILE *DirectReader::getFileHandle( const char *file_name, int &compression_type,
     capital_name[ len ] = '\0';
 //Mion: need to do more careful SJIS checking in this next part
     bool has_nonascii = false;
+    (void)has_nonascii;
     for ( i=0 ; i<len ; i++ ){
         if ((unsigned char)capital_name[i] >= 0x80)
             has_nonascii = true;

--- a/Encoding.cpp
+++ b/Encoding.cpp
@@ -48,7 +48,7 @@ int Encoding::getBytes(unsigned char ch, int code)
         if ((ch & 0xe0) == 0xe0 || (ch & 0xe0) == 0x80) return 2;
     }
     else{
-        if (0    <= ch && ch < 0x80) return 1;
+        if (ch < 0x80) return 1;
         if (0xc0 <= ch && ch < 0xe0) return 2;
         if (0xe0 <= ch && ch < 0xf0) return 3;
         if (0xf0 <= ch && ch < 0xf8) return 4;

--- a/NsaReader.cpp
+++ b/NsaReader.cpp
@@ -159,7 +159,7 @@ int NsaReader::processArchives( const DirPaths &path )
 
 #else //def TOOLS_BUILD
 
-NsaReader::ArchiveInfo* NsaReader::openForCreate( const char *nsa_name, int archive_type, int nsaoffset )
+NsaReader::ArchiveInfo* NsaReader::openForCreate( const char *nsa_name, int /*archive_type*/, int nsaoffset )
 {
     sar_flag = false;
     nsa_offset = nsaoffset;

--- a/ONScripterLabel.h
+++ b/ONScripterLabel.h
@@ -101,6 +101,8 @@
 
 #define KEYPRESS_NULL ((SDLKey)(SDLK_LAST+1)) // "null" for keypress variables
 
+void clearTimer(SDL_TimerID &timer_id);
+
 class ONScripterLabel : public ScriptParser
 {
 public:

--- a/ONScripterLabel_effect.cpp
+++ b/ONScripterLabel_effect.cpp
@@ -284,7 +284,7 @@ bool ONScripterLabel::doEffect( EffectLink *effect, bool clear_dirty_region )
                      effect_no);
             errorAndCont(script_h.errbuf);
         }
-
+        // fall through
       case 10: // Cross fade
         height = 256 * effect_counter / effect_duration;
         effectBlend( NULL, ALPHA_BLEND_CONST, height, &dirty_rect.bounding_box );
@@ -518,6 +518,9 @@ bool ONScripterLabel::doEffect( EffectLink *effect, bool clear_dirty_region )
     }
 }
 
+// TODO: Remove when GCC bug is resolved: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110091
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-pointer="
 void ONScripterLabel::drawEffect(SDL_Rect *dst_rect, SDL_Rect *src_rect, SDL_Surface *surface)
 {
     SDL_Rect clipped_rect;
@@ -531,6 +534,7 @@ void ONScripterLabel::drawEffect(SDL_Rect *dst_rect, SDL_Rect *src_rect, SDL_Sur
 
     SDL_BlitSurface(surface, src_rect, accumulation_surface, dst_rect);
 }
+#pragma GCC diagnostic pop
 
 void ONScripterLabel::generateMosaic( SDL_Surface *src_surface, int level )
 {

--- a/ONScripterLabel_effect_breakup.cpp
+++ b/ONScripterLabel_effect_breakup.cpp
@@ -213,7 +213,7 @@ void ONScripterLabel::initBreakup( char *params )
     }
 }
 
-void ONScripterLabel::effectBreakup( char *params, int duration )
+void ONScripterLabel::effectBreakup( char* /*params*/, int duration )
 {
     int x_dir = -1;
     int y_dir = -1;

--- a/ONScripterLabel_effect_trig.cpp
+++ b/ONScripterLabel_effect_trig.cpp
@@ -53,7 +53,7 @@ void ONScripterLabel::buildCosTable()
 //
 // Emulation of Takashi Toyama's "trvswave.dll" NScripter plugin effect
 //
-void ONScripterLabel::effectTrvswave( char *params, int duration )
+void ONScripterLabel::effectTrvswave( char* /*params*/, int duration )
 {
     enum {
         //some constants for trvswave

--- a/ONScripterLabel_event.cpp
+++ b/ONScripterLabel_event.cpp
@@ -78,7 +78,7 @@ SDL_TimerID timer_seqmusic_id = NULL;
 #endif
 bool ext_music_play_once_flag = false;
 
-static inline void clearTimer(SDL_TimerID &timer_id)
+void clearTimer(SDL_TimerID &timer_id)
 {
     if (timer_id != NULL ) {
         SDL_RemoveTimer( timer_id );
@@ -109,7 +109,7 @@ extern "C" void oggcallback( void *userdata, Uint8 *stream, int len )
     }
 }
 
-extern "C" Uint32 SDLCALL animCallback( Uint32 interval, void *param )
+extern "C" Uint32 SDLCALL animCallback( Uint32 /*interval*/, void* /*param*/ )
 {
     clearTimer( anim_timer_id );
 
@@ -120,7 +120,7 @@ extern "C" Uint32 SDLCALL animCallback( Uint32 interval, void *param )
     return 0;
 }
 
-extern "C" Uint32 SDLCALL breakCallback(Uint32 interval, void *param)
+extern "C" Uint32 SDLCALL breakCallback( Uint32 /*interval*/, void* /*param*/ )
 {
     clearTimer(break_id);
 
@@ -131,7 +131,7 @@ extern "C" Uint32 SDLCALL breakCallback(Uint32 interval, void *param)
     return 0;
 }
 
-extern "C" Uint32 SDLCALL timerCallback( Uint32 interval, void *param )
+extern "C" Uint32 SDLCALL timerCallback( Uint32 /*interval*/, void* /*param*/ )
 {
     clearTimer( timer_id );
 
@@ -142,7 +142,7 @@ extern "C" Uint32 SDLCALL timerCallback( Uint32 interval, void *param )
     return 0;
 }
 
-extern "C" Uint32 cdaudioCallback( Uint32 interval, void *param )
+extern "C" Uint32 cdaudioCallback( Uint32 /*interval*/, void* /*param*/ )
 {
     clearTimer( timer_cdaudio_id );
 
@@ -180,7 +180,7 @@ extern "C" Uint32 SDLCALL silentmovieCallback( Uint32 interval, void *param )
 // crashing in Mac OS X after a midi is looped for the first time.  Recommend for
 // integration.  This is the work of Ben Carter.  [Seung Park, 20060621]
 #if defined(MACOSX)
-extern "C" Uint32 seqmusicSDLCallback( Uint32 interval, void *param )
+extern "C" Uint32 seqmusicSDLCallback( Uint32 interval, void* /*param*/ )
 {
 	SDL_Event event;
 	event.type = ONS_SEQMUSIC_EVENT;
@@ -189,7 +189,7 @@ extern "C" Uint32 seqmusicSDLCallback( Uint32 interval, void *param )
 }
 #endif
 
-void seqmusicCallback( int sig )
+void seqmusicCallback( int /*sig*/ )
 {
 #ifdef LINUX
     int status;
@@ -202,7 +202,7 @@ void seqmusicCallback( int sig )
     }
 }
 
-void musicCallback( int sig )
+void musicCallback( int /*sig*/ )
 {
 #ifdef LINUX
     int status;
@@ -280,6 +280,7 @@ SDL_keysym ONScripterLabel::transKey(SDL_keysym key, bool isdown)
 
 SDLKey transJoystickButton(Uint8 button)
 {
+    (void)button;
 #ifdef PSP
     SDLKey button_map[] = { SDLK_ESCAPE, /* TRIANGLE */
                             SDLK_RETURN, /* CIRCLE   */
@@ -980,6 +981,7 @@ bool ONScripterLabel::keyDownEvent( SDL_KeyboardEvent *event )
     switch ( event->keysym.sym ) {
       case SDLK_RCTRL:
         ctrl_pressed_status  |= 0x01;
+        // fall through
       case SDLK_LCTRL:
         if (event->keysym.sym == SDLK_LCTRL)
             ctrl_pressed_status  |= 0x02;
@@ -1490,6 +1492,8 @@ void ONScripterLabel::runEventLoop()
 
           case SDL_MOUSEBUTTONDOWN:
             if ( !btndown_flag ) break;
+
+            // fall through
           case SDL_MOUSEBUTTONUP:
             ret = mousePressEvent( (SDL_MouseButtonEvent*)&event );
             if (ret) return;
@@ -1503,7 +1507,8 @@ void ONScripterLabel::runEventLoop()
             event.key.keysym.sym = transJoystickButton(event.jbutton.button);
             if(event.key.keysym.sym == SDLK_UNKNOWN)
                 break;
-
+            
+            // fall through
           case SDL_KEYDOWN:
             event.key.keysym = transKey(event.key.keysym, true);
             ret = keyDownEvent( (SDL_KeyboardEvent*)&event );
@@ -1520,7 +1525,8 @@ void ONScripterLabel::runEventLoop()
             event.key.keysym.sym = transJoystickButton(event.jbutton.button);
             if(event.key.keysym.sym == SDLK_UNKNOWN)
                 break;
-
+            
+            // fall through
           case SDL_KEYUP:
             event.key.keysym = transKey(event.key.keysym, false);
             keyUpEvent( (SDL_KeyboardEvent*)&event );
@@ -1570,6 +1576,8 @@ void ONScripterLabel::runEventLoop()
             if (event_mode & WAIT_VOICE_MODE)
                 voice_just_ended = true;
             event_mode &= ~WAIT_VOICE_MODE;
+            
+            // fall through
           case ONS_BREAK_EVENT:
             if ((event_mode & WAIT_VOICE_MODE) && wave_sample[0]){
                 break;
@@ -1608,6 +1616,8 @@ void ONScripterLabel::runEventLoop()
 
           case SDL_ACTIVEEVENT:
             if ( !event.active.gain ) break;
+            
+            // fall through
           case SDL_VIDEOEXPOSE:
               SDL_UpdateRect( screen_surface, 0, 0, screen_width, screen_height );
               break;

--- a/ONScripterLabel_file.cpp
+++ b/ONScripterLabel_file.cpp
@@ -193,6 +193,9 @@ int ONScripterLabel::loadSaveFile( int no, bool input_flag )
     int  i, j, k, address;
     int  file_version;
 
+    // FIXME: Use this?
+    (void)address;
+
     /* ---------------------------------------- */
     /* Load magic number */
     for ( i=0 ; i<(int)strlen( SAVEFILE_MAGIC_NUMBER ) ; i++ )
@@ -250,9 +253,12 @@ int ONScripterLabel::loadSaveFile( int no, bool input_flag )
         current_page->max_text = (num_xy[0]*2+1)*num_xy[1];
         if (sentence_font.getTateyokoMode() == Fontinfo::TATE_MODE)
             current_page->max_text = (num_xy[1]*2+1)*num_xy[0];
+
         int xy[2];
         xy[0] = readInt();
         xy[1] = readInt();
+        (void)xy;
+        
         if ( current_page->text ) delete[] current_page->text;
         current_page->text = new char[ current_page->max_text ];
         current_page->text_count = 0;

--- a/ONScripterLabel_sound.cpp
+++ b/ONScripterLabel_sound.cpp
@@ -67,11 +67,6 @@ static void setupWaveHeader( unsigned char *buffer, int channels, int bits,
                              unsigned long rate, unsigned long data_length,
                              unsigned int extra_bytes=0, unsigned char *extra_ptr=NULL );
 
-static inline void clearTimer(SDL_TimerID &timer_id)
-{
-    clearTimer( timer_id );
-}
-
 extern bool ext_music_play_once_flag;
 
 extern "C"{
@@ -884,6 +879,8 @@ int ONScripterLabel::playMPEG( const char *filename, bool async_flag, bool use_p
 
 int ONScripterLabel::playAVI( const char *filename, bool click_flag )
 {
+    (void)filename, (void)click_flag;
+
 #ifdef USE_AVIFILE
     char *absolute_filename = new char[ strlen(archive_path) + strlen(filename) + 1 ];
     sprintf( absolute_filename, "%s%s", archive_path, filename );
@@ -1136,7 +1133,7 @@ static int oc_seek_func(void *datasource, ogg_int64_t offset, int whence)
     return 0;
 }
 
-static int oc_close_func(void *datasource)
+static int oc_close_func(void* /*datasource*/)
 {
     return 0;
 }

--- a/ONScripterLabel_text.cpp
+++ b/ONScripterLabel_text.cpp
@@ -844,11 +844,6 @@ void ONScripterLabel::startRuby(char *buf, Fontinfo &info)
     ruby_struct.body_count = 0;
     ruby_struct.ruby_count = 0;
 
-    if (script_h.enc.getEncoding() == Encoding::CODE_UTF8) {
-        char check_text[5] = {'\0', '\0', '\0', '\0', '\0'};
-        int n;
-    }
-
     int n = 0;
     char check_text[5] = {'\0', '\0', '\0', '\0', '\0'};
 
@@ -1385,7 +1380,7 @@ bool ONScripterLabel::processText()
     return false;
 }
 
-char ONScripterLabel::doLineBreak(bool isHardBreak)
+char ONScripterLabel::doLineBreak(bool /*isHardBreak*/)
 // Mion: for text processing
 {
     sentence_font.newLine();
@@ -1545,7 +1540,7 @@ bool ONScripterLabel::processBreaks(bool cont_line, LineBreakType style)
     if (debug_level > 1) debug_msg = 1;
     char *string_buffer = script_h.getStringBuffer();
     if (debug_msg) printf("\n\nBeginning processbreaks for string buffer:\n>>%s<<\n", string_buffer);
-    unsigned int i=0, j=0, o=0;
+    unsigned int i=0, j=0;
     unsigned int len;
     len = (int)strlen(string_buffer);
     int cmd=0;
@@ -2124,6 +2119,11 @@ float ONScripterLabel::strpxlen(const char *buf, Fontinfo *fi)
     float w = 0.0;
     char two_chars[7] = {};
     char num_chars = 1;
+
+    // FIXME: Use these
+    (void)two_chars;
+    (void)num_chars;
+
     float advanced = 0.0;
     while (buf[0] != '\0')
     {

--- a/ONScripterReporter.cpp
+++ b/ONScripterReporter.cpp
@@ -10,4 +10,4 @@ bool ONScripterReporter::reportError( const char *title, const char *errstr, boo
     }
 
     return result;
-};
+}

--- a/ScriptHandler.cpp
+++ b/ScriptHandler.cpp
@@ -1299,7 +1299,6 @@ int ScriptHandler::checkClickstr(const char *buf, bool recursive_flag)
     if (clickstr_list == NULL) return 0;
     bool only_double_byte_check = true;
     char *click_buf = clickstr_list;
-    int n;
 
     while(click_buf[0]){
 
@@ -1599,7 +1598,7 @@ int ScriptHandler::readScript( DirPaths &path )
 
     FILE *fp = NULL;
     char filename[12];
-    char *file_extension = "";
+    const char *file_extension = "";
     int i, n=0, encrypt_mode = 0;
     while ((fp == NULL) && (n<archive_path->get_num_paths())) {
         const char *curpath = archive_path->get_path(n);

--- a/ScriptHandler.h
+++ b/ScriptHandler.h
@@ -180,7 +180,7 @@ public:
     void setEndStatus(int val){ end_status |= val; };
     inline int getEndStatus(){ return end_status; };
     inline void toggle1ByteEndStatus() {
-        if (end_status && END_1BYTE_CHAR)
+        if (end_status & END_1BYTE_CHAR)
             end_status &= ~END_1BYTE_CHAR;
         else
             end_status |= END_1BYTE_CHAR;

--- a/ScriptParser.h
+++ b/ScriptParser.h
@@ -487,8 +487,10 @@ protected:
         Page(): next(NULL), previous(NULL),
                 text(NULL), max_text(0), text_count(0), tag(NULL){}
         ~Page(){
-            if (text) delete[] text; text = NULL;
-            if (tag)  delete[] tag;  tag = NULL;
+            if (text) delete[] text;
+            text = NULL;
+            if (tag)  delete[] tag;
+            tag = NULL;
             next = previous = NULL;
         }
         int add(unsigned char ch){

--- a/ScriptParser_command.cpp
+++ b/ScriptParser_command.cpp
@@ -824,8 +824,8 @@ int ScriptParser::luasubCommand()
 
 int ScriptParser::luacallCommand()
 {
-    const char *label = NULL;
-    label = script_h.readLabel();
+    const char *label = script_h.readLabel();
+    (void)label;
 
 #ifdef USE_LUA
     lua_handler.addCallback(label);

--- a/tools/arcmake.cpp
+++ b/tools/arcmake.cpp
@@ -60,6 +60,8 @@ int processFile(reader::ArchiveInfo *ai, reader::FileInfo *fi,
                 char *fullname, char *name, unsigned long &offset,
                 bool enhanced_flag )
 {
+    (void)enhanced_flag;
+
     FILE *fp = NULL;
     char magic[5];
     char fullpath[512];

--- a/tools/conv_shared.cpp
+++ b/tools/conv_shared.cpp
@@ -123,7 +123,7 @@ void rescaleImage( unsigned char *original_buffer, int width, int height, int by
 }
 
 
-void init_source (j_decompress_ptr cinfo)
+void init_source (j_decompress_ptr /*cinfo*/)
 {
 }
 
@@ -145,7 +145,7 @@ void skip_input_data (j_decompress_ptr cinfo, long num_bytes)
     src->pub.bytes_in_buffer -= (size_t) num_bytes;
 }
 
-void term_source (j_decompress_ptr cinfo)
+void term_source (j_decompress_ptr /*cinfo*/)
 {
 }
 
@@ -167,7 +167,7 @@ boolean empty_output_buffer (j_compress_ptr cinfo)
     return TRUE;
 }
 
-void term_destination (j_compress_ptr cinfo)
+void term_destination (j_compress_ptr /*cinfo*/)
 {
 }
 
@@ -340,7 +340,7 @@ void my_write_data(libpng::png_structp png_ptr, libpng::png_bytep data,
         *(dst_mgr->buf++) = *data++;
 }
 
-void my_flush_data(libpng::png_structp png_ptr)
+void my_flush_data(libpng::png_structp /*png_ptr*/)
 {
 }
 

--- a/tools/libgnurx/regex_internal.h
+++ b/tools/libgnurx/regex_internal.h
@@ -421,8 +421,10 @@ static unsigned int re_string_context_at (const re_string_t *input, int idx,
 #define re_string_set_index(pstr,idx) ((pstr)->cur_idx = (idx))
 
 #ifdef __GNUC__
+#ifndef alloca
 # define alloca(size)   __builtin_alloca (size)
 # define HAVE_ALLOCA 1
+#endif
 #elif defined(_MSC_VER)
 # include <malloc.h>
 # define alloca _alloca


### PR DESCRIPTION
There's a ton of various warnings we have, this resolves _most_ of them, with the intent to introduce no functional changes. There's a few warnings I haven't addressed yet due to either being unsure how to fix it without introducing a functional change, or them only appearing on Linux/when building our deps. I'll work on those in another PR.

Some categories of issues along with a few select issues:
  - Unused variable: These range from parameters that aren't used, because they're a base class impl, or a callback that doesn't need the parameters, to code that's been orphaned and is unclear if they're needed anymore, to code that's only used on some platforms, but are visible on all of them. Depending on the scenario, these were deleted, their names removed from function definitions, or casted to void to let the compiler know it's intentional.
  - Case fallthrough: These were all straightforward and intentional. Used a comment to let gcc know. (There's also a C++17 attribute for this, but we're on C++98.)
  - Function casting: `GetProcAddress` just will always give us warnings due to how GCC handles function conversions and it's return type. Switched to using a wrapper provided by SDL to avoid it.
  - An actual compiler bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110091
  - An infinite recursion


We might want to make macros to use instead of `void` casting unused variables to make their situations clearer, but for now I figured that simpler was better.