### PR TITLE
Split jpeg conversion functions into their own file

### DIFF
--- a/Makefile.onscripter
+++ b/Makefile.onscripter
@@ -51,14 +51,15 @@ SARMAKE_OBJS  = $(TDIR)sarmake$(OBJSUFFIX) $(TDIR)DirectReader$(OBJSUFFIX)	\
 SARCONV_OBJS  = $(TDIR)sarconv$(OBJSUFFIX) $(TDIR)DirectReader$(OBJSUFFIX)	\
                 $(TDIR)SarReader$(OBJSUFFIX) $(TDIR)DirPaths$(OBJSUFFIX)	\
                 $(TDIR)resize_image$(OBJSUFFIX) $(TDIR)conv_shared$(OBJSUFFIX)  \
-                $(TDIR)sjis2utf16$(OBJSUFFIX)
+                $(TDIR)conv_shared_jpeg$(OBJSUFFIX) $(TDIR)sjis2utf16$(OBJSUFFIX)
 NSADEC_OBJS   = $(TDIR)nsadec$(OBJSUFFIX) $(TDIR)DirectReader$(OBJSUFFIX)	\
                 $(TDIR)SarReader$(OBJSUFFIX) $(TDIR)NsaReader$(OBJSUFFIX)	\
                 $(TDIR)DirPaths$(OBJSUFFIX) $(TDIR)sjis2utf16$(OBJSUFFIX)
 NSACONV_OBJS  = $(TDIR)nsaconv$(OBJSUFFIX) $(TDIR)DirectReader$(OBJSUFFIX)	\
                 $(TDIR)SarReader$(OBJSUFFIX) $(TDIR)NsaReader$(OBJSUFFIX)	\
                 $(TDIR)DirPaths$(OBJSUFFIX) $(TDIR)resize_image$(OBJSUFFIX)	\
-                $(TDIR)conv_shared$(OBJSUFFIX) $(TDIR)sjis2utf16$(OBJSUFFIX)
+                $(TDIR)conv_shared$(OBJSUFFIX) $(TDIR)sjis2utf16$(OBJSUFFIX) \
+                $(TDIR)conv_shared_jpeg$(OBJSUFFIX) 
 NSAMAKE_OBJS  = $(TDIR)nsamake$(OBJSUFFIX) $(TDIR)DirectReader$(OBJSUFFIX)	\
                 $(TDIR)SarReader$(OBJSUFFIX) $(TDIR)NsaReader$(OBJSUFFIX)	\
                 $(TDIR)DirPaths$(OBJSUFFIX) $(TDIR)sjis2utf16$(OBJSUFFIX)
@@ -68,12 +69,13 @@ NS2DEC_OBJS   = $(TDIR)ns2dec$(OBJSUFFIX) $(TDIR)DirectReader$(OBJSUFFIX)	\
 NS2CONV_OBJS  = $(TDIR)ns2conv$(OBJSUFFIX) $(TDIR)DirectReader$(OBJSUFFIX)	\
                 $(TDIR)SarReader$(OBJSUFFIX) $(TDIR)NsaReader$(OBJSUFFIX)	\
                 $(TDIR)DirPaths$(OBJSUFFIX) $(TDIR)resize_image$(OBJSUFFIX)	\
-                $(TDIR)conv_shared$(OBJSUFFIX) $(TDIR)sjis2utf16$(OBJSUFFIX)
+                $(TDIR)conv_shared$(OBJSUFFIX) $(TDIR)sjis2utf16$(OBJSUFFIX) \
+                $(TDIR)conv_shared_jpeg$(OBJSUFFIX) 
 NS2MAKE_OBJS  = $(TDIR)ns2make$(OBJSUFFIX) $(TDIR)DirectReader$(OBJSUFFIX)	\
                 $(TDIR)SarReader$(OBJSUFFIX) $(TDIR)NsaReader$(OBJSUFFIX)	\
                 $(TDIR)DirPaths$(OBJSUFFIX) $(TDIR)sjis2utf16$(OBJSUFFIX)
 BATCONV_OBJS  = $(TDIR)batchconv$(OBJSUFFIX) $(TDIR)resize_image$(OBJSUFFIX)	\
-                $(TDIR)conv_shared$(OBJSUFFIX)
+                $(TDIR)conv_shared$(OBJSUFFIX) $(TDIR)conv_shared_jpeg$(OBJSUFFIX)
 NBZDEC_OBJS   = $(TDIR)nbzdec$(OBJSUFFIX) $(TDIR)DirectReader$(OBJSUFFIX)	\
                 $(TDIR)SarReader$(OBJSUFFIX) $(TDIR)DirPaths$(OBJSUFFIX)	\
                 $(TDIR)sjis2utf16$(OBJSUFFIX)
@@ -210,7 +212,8 @@ $(TDIR)ns2dec$(OBJSUFFIX): $(READER_HEADER) SarReader.h NsaReader.h
 $(TDIR)ns2conv$(OBJSUFFIX): $(READER_HEADER) SarReader.h NsaReader.h
 $(TDIR)ns2make$(OBJSUFFIX): $(READER_HEADER) SarReader.h NsaReader.h
 $(TDIR)nbzdec$(OBJSUFFIX): $(READER_HEADER) SarReader.h
-$(TDIR)conv_shared$(OBJSUFFIX): resize_image.h
+$(TDIR)conv_shared$(OBJSUFFIX): $(TDIR)conv_shared.h resize_image.h
+$(TDIR)conv_shared_jpeg$(OBJSUFFIX): $(TDIR)conv_shared.h resize_image.h
 $(TDIR)SarReader$(OBJSUFFIX):    $(READER_HEADER) SarReader.h 
 $(TDIR)NsaReader$(OBJSUFFIX):    $(READER_HEADER) SarReader.h NsaReader.h 
 $(TDIR)DirectReader$(OBJSUFFIX): $(READER_HEADER) DirectReader.h

--- a/tools/conv_shared.cpp
+++ b/tools/conv_shared.cpp
@@ -33,12 +33,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <jpeglib.h>
+#include "conv_shared.h"
 
 //Mion: for png image file support
-namespace libpng {
 #include <png.h>
-}
 
 #include <bzlib.h>
 #include "resize_image.h"
@@ -51,29 +49,16 @@ size_t rescaled_tmp2_length = 0;
 unsigned char *rescaled_tmp_buffer = NULL;
 size_t rescaled_tmp_length = 0;
 
-static unsigned char *restored_buffer = NULL;
-static size_t restored_length = 0;
+unsigned char *restored_buffer = NULL;
+size_t restored_length = 0;
 
 #define INPUT_BUFFER_SIZE       4096
-typedef struct {
-    struct jpeg_source_mgr pub;
-
-    unsigned char *buf;
-    size_t left;
-} my_source_mgr;
-
-typedef struct {
-    struct jpeg_destination_mgr pub;
-
-    unsigned char *buf;
-    size_t left;
-} my_destination_mgr;
 
 //Mion: for png image file support
 typedef struct {
-    libpng::png_infop info_ptr;
+    png_infop info_ptr;
     int number_of_passes;
-    libpng::png_bytep * row_pointers;
+    png_bytep * row_pointers;
 
     unsigned char *buf;
     size_t left;
@@ -123,192 +108,11 @@ void rescaleImage( unsigned char *original_buffer, int width, int height, int by
 }
 
 
-void init_source (j_decompress_ptr cinfo)
-{
-}
-
-boolean fill_input_buffer (j_decompress_ptr cinfo)
-{
-    my_source_mgr *src = (my_source_mgr *)cinfo->src;
-    
-    src->pub.next_input_byte = src->buf;
-    src->pub.bytes_in_buffer = src->left;
-
-    return TRUE;
-}
-
-void skip_input_data (j_decompress_ptr cinfo, long num_bytes)
-{
-    my_source_mgr *src = (my_source_mgr *)cinfo->src;
-    
-    src->pub.next_input_byte += (size_t) num_bytes;
-    src->pub.bytes_in_buffer -= (size_t) num_bytes;
-}
-
-void term_source (j_decompress_ptr cinfo)
-{
-}
-
-void init_destination (j_compress_ptr cinfo)
-{
-    my_destination_mgr * dest = (my_destination_mgr *) cinfo->dest;
-
-    dest->pub.next_output_byte = dest->buf;
-    dest->pub.free_in_buffer = dest->left;
-}
-
-boolean empty_output_buffer (j_compress_ptr cinfo)
-{
-    my_destination_mgr * dest = (my_destination_mgr *) cinfo->dest;
-
-    dest->pub.next_output_byte = dest->buf;
-    dest->pub.free_in_buffer = dest->left;
-    
-    return TRUE;
-}
-
-void term_destination (j_compress_ptr cinfo)
-{
-}
-
-size_t rescaleJPEGWrite( unsigned int width, unsigned int height, int byte_per_pixel, unsigned char **rescaled_buffer,
-                         int quality, bool bmp2jpeg_flag, int num_of_cells )
-{
-    jpeg_error_mgr jerr;
-    struct jpeg_compress_struct cinfo2;
-    JSAMPROW row_pointer[1];
-    
-    cinfo2.err = jpeg_std_error(&jerr);
-    jpeg_create_compress(&cinfo2);
-
-    cinfo2.dest = (struct jpeg_destination_mgr *)
-        (*cinfo2.mem->alloc_small) ((j_common_ptr) &cinfo2, JPOOL_PERMANENT,
-                                    sizeof(my_destination_mgr));
-    my_destination_mgr * dest = (my_destination_mgr *) cinfo2.dest;
-
-    cinfo2.image_width = (int)((width / num_of_cells) * scale_ratio_upper / scale_ratio_lower) * num_of_cells;
-    if ( cinfo2.image_width == 0 ) cinfo2.image_width = num_of_cells;
-    cinfo2.image_height = (int)(height * scale_ratio_upper / scale_ratio_lower);
-    if ( cinfo2.image_height == 0 ) cinfo2.image_height = 1;
-
-    size_t total_size = cinfo2.image_width * byte_per_pixel * cinfo2.image_height;
-    if ((total_size + 0x400) > restored_length){
-        restored_length = total_size + 0x400;
-        if ( restored_buffer ) delete[] restored_buffer;
-        restored_buffer = new unsigned char[ restored_length ];
-        if ( *rescaled_buffer ) delete[] *rescaled_buffer;
-        *rescaled_buffer = new unsigned char[ restored_length ];
-    }
-
-    dest->buf = *rescaled_buffer;
-    dest->left = restored_length;
-
-    dest->pub.init_destination = init_destination;
-    dest->pub.empty_output_buffer = empty_output_buffer;
-    dest->pub.term_destination = term_destination;
-
-    cinfo2.input_components = byte_per_pixel;
-    if ( cinfo2.input_components == 1 )
-        cinfo2.in_color_space = JCS_GRAYSCALE;
-    else
-        cinfo2.in_color_space = JCS_RGB;
-
-    jpeg_set_defaults(&cinfo2);
-    jpeg_set_quality(&cinfo2, quality, TRUE );
-    cinfo2.optimize_coding = TRUE;
-    //jpeg_simple_progression (&cinfo2);
-    jpeg_start_compress(&cinfo2, TRUE);
-
-    int row_stride = cinfo2.image_width * byte_per_pixel;
-
-    while (cinfo2.next_scanline < cinfo2.image_height) {
-        if (bmp2jpeg_flag){
-            unsigned char *src = row_pointer[0] = &rescaled_tmp_buffer[(cinfo2.image_height - 1 - cinfo2.next_scanline) * row_stride];
-            for(unsigned int i=0 ; i<cinfo2.image_width ; i++, src+=3){
-                unsigned char tmp = src[2];
-                src[2] = src[0];
-                src[0] = tmp;
-            }
-        }
-        else{
-            row_pointer[0] = &rescaled_tmp_buffer[cinfo2.next_scanline * row_stride];
-        }
-        jpeg_write_scanlines(&cinfo2, row_pointer, 1);
-    }
-
-    jpeg_finish_compress(&cinfo2);
-    size_t datacount = dest->left - dest->pub.free_in_buffer;
-
-    jpeg_destroy_compress(&cinfo2);
-
-    return datacount;
-}
-
-size_t rescaleJPEG( unsigned char *original_buffer, size_t length,
-                    unsigned char **rescaled_buffer, int quality, int num_of_cells=1 )
-{
-    struct jpeg_decompress_struct cinfo;
-    jpeg_error_mgr jerr;
-
-    cinfo.err = jpeg_std_error(&jerr);
-    jpeg_create_decompress(&cinfo);
-
-    cinfo.src = (struct jpeg_source_mgr *)
-        (*cinfo.mem->alloc_small) ((j_common_ptr) &cinfo, JPOOL_PERMANENT,
-                                   sizeof(my_source_mgr));
-    my_source_mgr * src = (my_source_mgr *) cinfo.src;
-    
-    src->buf = original_buffer;
-    src->left = length;
-
-    src->pub.init_source = init_source;
-    src->pub.fill_input_buffer = fill_input_buffer;
-    src->pub.skip_input_data = skip_input_data;
-    src->pub.resync_to_restart = jpeg_resync_to_restart;
-    src->pub.term_source = term_source;
-
-    src->pub.bytes_in_buffer = 0;
-    src->pub.next_input_byte = NULL;
-
-    jpeg_read_header(&cinfo, TRUE);
-    jpeg_start_decompress(&cinfo);
-
-    if ( cinfo.output_width * cinfo.output_height * cinfo.output_components + 0x400 > restored_length ){
-        restored_length = cinfo.output_width * cinfo.output_height * cinfo.output_components + 0x400;
-        if ( restored_buffer ) delete[] restored_buffer;
-        restored_buffer = new unsigned char[ restored_length ];
-        if ( *rescaled_buffer ) delete[] *rescaled_buffer;
-        *rescaled_buffer = new unsigned char[ restored_length ];
-    }
-    int row_stride = cinfo.output_width * cinfo.output_components;
-
-    JSAMPARRAY buf = (*cinfo.mem->alloc_sarray)
-        ((j_common_ptr) &cinfo, JPOOL_IMAGE, row_stride, 1);
-
-    unsigned char *buf_p = restored_buffer;
-    while (cinfo.output_scanline < cinfo.output_height) {
-        jpeg_read_scanlines(&cinfo, buf, 1);
-        memcpy( buf_p, buf[0], row_stride );
-        buf_p += cinfo.output_width * cinfo.output_components;
-    }
-
-    rescaleImage( restored_buffer, cinfo.output_width, cinfo.output_height,
-                  cinfo.output_components, false, false, false, num_of_cells );
-
-    size_t datacount = rescaleJPEGWrite(cinfo.output_width, cinfo.output_height,
-                                        cinfo.output_components, rescaled_buffer,
-                                        quality, false, num_of_cells);
-    printf(" JPG");
-    jpeg_destroy_decompress(&cinfo);
-
-    return datacount;
-}
 
 //Mion: functions for png image file support
-void my_read_data(libpng::png_structp png_ptr, libpng::png_bytep data,
-                  libpng::png_size_t length)
+void my_read_data(png_structp png_ptr, png_bytep data,
+                  png_size_t length)
 {
-    using namespace libpng;
     if ( !(length > 0) || (png_get_io_ptr(png_ptr) == NULL))
         return;
 
@@ -320,10 +124,9 @@ void my_read_data(libpng::png_structp png_ptr, libpng::png_bytep data,
         *data++ = *(src_mgr->buf++);
 }
 
-void my_write_data(libpng::png_structp png_ptr, libpng::png_bytep data,
-                   libpng::png_size_t length)
+void my_write_data(png_structp png_ptr, png_bytep data,
+                   png_size_t length)
 {
-    using namespace libpng;
     if ( !(length > 0) || (png_get_io_ptr(png_ptr) == NULL))
         return;
 
@@ -340,14 +143,13 @@ void my_write_data(libpng::png_structp png_ptr, libpng::png_bytep data,
         *(dst_mgr->buf++) = *data++;
 }
 
-void my_flush_data(libpng::png_structp png_ptr)
+void my_flush_data(png_structp png_ptr)
 {
 }
 
 size_t rescalePNGWrite( unsigned int width, unsigned int height, int byte_per_pixel, unsigned char **rescaled_buffer,
-                        libpng::png_structp png_ptr, libpng::png_infop info_ptr, bool palette_flag, int num_of_cells )
+                        png_structp png_ptr, png_infop info_ptr, bool palette_flag, int num_of_cells )
 {
-    using namespace libpng;
     png_structp png_dst_ptr;
     my_png_mgr png_dst_mgr;
     int rowbytes;
@@ -468,7 +270,6 @@ size_t rescalePNGWrite( unsigned int width, unsigned int height, int byte_per_pi
 size_t rescalePNG( unsigned char *original_buffer, size_t length,
                     unsigned char **rescaled_buffer, int num_of_cells=1 )
 {
-    using namespace libpng;
     unsigned int width, height;
     bool palette_flag = false;
     png_byte color_type, bit_depth;

--- a/tools/conv_shared.h
+++ b/tools/conv_shared.h
@@ -1,0 +1,31 @@
+#ifndef __CONV_SHARED__
+#define __CONV_SHARED__
+
+#include <stdlib.h>
+
+extern int scale_ratio_upper;
+extern int scale_ratio_lower;
+extern unsigned char *rescaled_tmp2_buffer;
+extern size_t rescaled_tmp2_length;
+extern unsigned char *rescaled_tmp_buffer;
+extern size_t rescaled_tmp_length;
+extern unsigned char *restored_buffer;
+extern size_t restored_length;
+#define INPUT_BUFFER_SIZE       4096
+
+
+void rescaleImage( unsigned char *original_buffer, int width, int height, int byte_per_pixel,
+                   bool src_pad_flag, bool dst_pad_flag, bool palette_flag, int num_of_cells );
+
+//boolean fill_input_buffer (j_decompress_ptr cinfo);
+//void skip_input_data (j_decompress_ptr cinfo, long num_bytes);
+//void term_source (j_decompress_ptr cinfo);
+//void init_destination (j_compress_ptr cinfo);
+//boolean empty_output_buffer (j_compress_ptr cinfo);
+//void term_destination (j_compress_ptr cinfo);
+size_t rescaleJPEGWrite( unsigned int width, unsigned int height, int byte_per_pixel, unsigned char **rescaled_buffer,
+                         int quality, bool bmp2jpeg_flag, int num_of_cells );
+size_t rescaleJPEG( unsigned char *original_buffer, size_t length,
+                    unsigned char **rescaled_buffer, int quality, int num_of_cells=1 );
+
+#endif

--- a/tools/conv_shared_jpeg.cpp
+++ b/tools/conv_shared_jpeg.cpp
@@ -1,0 +1,205 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <jpeglib.h>
+
+#include "conv_shared.h"
+#include "resize_image.h"
+
+typedef struct {
+    struct jpeg_source_mgr pub;
+
+    unsigned char *buf;
+    size_t left;
+} my_source_mgr;
+
+typedef struct {
+    struct jpeg_destination_mgr pub;
+
+    unsigned char *buf;
+    size_t left;
+} my_destination_mgr;
+
+void init_source (j_decompress_ptr cinfo)
+{
+}
+
+boolean fill_input_buffer (j_decompress_ptr cinfo)
+{
+    my_source_mgr *src = (my_source_mgr *)cinfo->src;
+    
+    src->pub.next_input_byte = src->buf;
+    src->pub.bytes_in_buffer = src->left;
+
+    return TRUE;
+}
+
+void skip_input_data (j_decompress_ptr cinfo, long num_bytes)
+{
+    my_source_mgr *src = (my_source_mgr *)cinfo->src;
+    
+    src->pub.next_input_byte += (size_t) num_bytes;
+    src->pub.bytes_in_buffer -= (size_t) num_bytes;
+}
+
+void term_source (j_decompress_ptr cinfo)
+{
+}
+
+void init_destination (j_compress_ptr cinfo)
+{
+    my_destination_mgr * dest = (my_destination_mgr *) cinfo->dest;
+
+    dest->pub.next_output_byte = dest->buf;
+    dest->pub.free_in_buffer = dest->left;
+}
+
+boolean empty_output_buffer (j_compress_ptr cinfo)
+{
+    my_destination_mgr * dest = (my_destination_mgr *) cinfo->dest;
+
+    dest->pub.next_output_byte = dest->buf;
+    dest->pub.free_in_buffer = dest->left;
+    
+    return TRUE;
+}
+
+void term_destination (j_compress_ptr cinfo)
+{
+}
+
+size_t rescaleJPEGWrite( unsigned int width, unsigned int height, int byte_per_pixel, unsigned char **rescaled_buffer,
+                         int quality, bool bmp2jpeg_flag, int num_of_cells )
+{
+    jpeg_error_mgr jerr;
+    struct jpeg_compress_struct cinfo2;
+    JSAMPROW row_pointer[1];
+    
+    cinfo2.err = jpeg_std_error(&jerr);
+    jpeg_create_compress(&cinfo2);
+
+    cinfo2.dest = (struct jpeg_destination_mgr *)
+        (*cinfo2.mem->alloc_small) ((j_common_ptr) &cinfo2, JPOOL_PERMANENT,
+                                    sizeof(my_destination_mgr));
+    my_destination_mgr * dest = (my_destination_mgr *) cinfo2.dest;
+
+    cinfo2.image_width = (int)((width / num_of_cells) * scale_ratio_upper / scale_ratio_lower) * num_of_cells;
+    if ( cinfo2.image_width == 0 ) cinfo2.image_width = num_of_cells;
+    cinfo2.image_height = (int)(height * scale_ratio_upper / scale_ratio_lower);
+    if ( cinfo2.image_height == 0 ) cinfo2.image_height = 1;
+
+    size_t total_size = cinfo2.image_width * byte_per_pixel * cinfo2.image_height;
+    if ((total_size + 0x400) > restored_length){
+        restored_length = total_size + 0x400;
+        if ( restored_buffer ) delete[] restored_buffer;
+        restored_buffer = new unsigned char[ restored_length ];
+        if ( *rescaled_buffer ) delete[] *rescaled_buffer;
+        *rescaled_buffer = new unsigned char[ restored_length ];
+    }
+
+    dest->buf = *rescaled_buffer;
+    dest->left = restored_length;
+
+    dest->pub.init_destination = init_destination;
+    dest->pub.empty_output_buffer = empty_output_buffer;
+    dest->pub.term_destination = term_destination;
+
+    cinfo2.input_components = byte_per_pixel;
+    if ( cinfo2.input_components == 1 )
+        cinfo2.in_color_space = JCS_GRAYSCALE;
+    else
+        cinfo2.in_color_space = JCS_RGB;
+
+    jpeg_set_defaults(&cinfo2);
+    jpeg_set_quality(&cinfo2, quality, TRUE );
+    cinfo2.optimize_coding = TRUE;
+    //jpeg_simple_progression (&cinfo2);
+    jpeg_start_compress(&cinfo2, TRUE);
+
+    int row_stride = cinfo2.image_width * byte_per_pixel;
+
+    while (cinfo2.next_scanline < cinfo2.image_height) {
+        if (bmp2jpeg_flag){
+            unsigned char *src = row_pointer[0] = &rescaled_tmp_buffer[(cinfo2.image_height - 1 - cinfo2.next_scanline) * row_stride];
+            for(unsigned int i=0 ; i<cinfo2.image_width ; i++, src+=3){
+                unsigned char tmp = src[2];
+                src[2] = src[0];
+                src[0] = tmp;
+            }
+        }
+        else{
+            row_pointer[0] = &rescaled_tmp_buffer[cinfo2.next_scanline * row_stride];
+        }
+        jpeg_write_scanlines(&cinfo2, row_pointer, 1);
+    }
+
+    jpeg_finish_compress(&cinfo2);
+    size_t datacount = dest->left - dest->pub.free_in_buffer;
+
+    jpeg_destroy_compress(&cinfo2);
+
+    return datacount;
+}
+
+size_t rescaleJPEG( unsigned char *original_buffer, size_t length,
+                    unsigned char **rescaled_buffer, int quality, int num_of_cells)
+{
+    struct jpeg_decompress_struct cinfo;
+    jpeg_error_mgr jerr;
+
+    cinfo.err = jpeg_std_error(&jerr);
+    jpeg_create_decompress(&cinfo);
+
+    cinfo.src = (struct jpeg_source_mgr *)
+        (*cinfo.mem->alloc_small) ((j_common_ptr) &cinfo, JPOOL_PERMANENT,
+                                   sizeof(my_source_mgr));
+    my_source_mgr * src = (my_source_mgr *) cinfo.src;
+    
+    src->buf = original_buffer;
+    src->left = length;
+
+    src->pub.init_source = init_source;
+    src->pub.fill_input_buffer = fill_input_buffer;
+    src->pub.skip_input_data = skip_input_data;
+    src->pub.resync_to_restart = jpeg_resync_to_restart;
+    src->pub.term_source = term_source;
+
+    src->pub.bytes_in_buffer = 0;
+    src->pub.next_input_byte = NULL;
+
+    jpeg_read_header(&cinfo, TRUE);
+    jpeg_start_decompress(&cinfo);
+
+    if ( cinfo.output_width * cinfo.output_height * cinfo.output_components + 0x400 > restored_length ){
+        restored_length = cinfo.output_width * cinfo.output_height * cinfo.output_components + 0x400;
+        if ( restored_buffer ) delete[] restored_buffer;
+        restored_buffer = new unsigned char[ restored_length ];
+        if ( *rescaled_buffer ) delete[] *rescaled_buffer;
+        *rescaled_buffer = new unsigned char[ restored_length ];
+    }
+    int row_stride = cinfo.output_width * cinfo.output_components;
+
+    JSAMPARRAY buf = (*cinfo.mem->alloc_sarray)
+        ((j_common_ptr) &cinfo, JPOOL_IMAGE, row_stride, 1);
+
+    unsigned char *buf_p = restored_buffer;
+    while (cinfo.output_scanline < cinfo.output_height) {
+        jpeg_read_scanlines(&cinfo, buf, 1);
+        memcpy( buf_p, buf[0], row_stride );
+        buf_p += cinfo.output_width * cinfo.output_components;
+    }
+
+    rescaleImage( restored_buffer, cinfo.output_width, cinfo.output_height,
+                  cinfo.output_components, false, false, false, num_of_cells );
+
+    size_t datacount = rescaleJPEGWrite(cinfo.output_width, cinfo.output_height,
+                                        cinfo.output_components, rescaled_buffer,
+                                        quality, false, num_of_cells);
+    printf(" JPG");
+    jpeg_destroy_decompress(&cinfo);
+
+    return datacount;
+}


### PR DESCRIPTION
This is a more complete fix to the libjpeg stuff we tried to tackle in #53 and #52. As I was experimenting with different versions of libjpeg it became clear that there was no correct way to include some of these headers together in the same TU. Thus splitting these functions off into their own TUs.

If desired I can also split off the libpng functions into their own TU as well, I just hadn't gotten around to doing it yet.