### PR TITLE
fix overlap csel dialogue (temp)

### DIFF
--- a/ONScripterLabel_text.cpp
+++ b/ONScripterLabel_text.cpp
@@ -295,7 +295,13 @@ void ONScripterLabel::drawChar( char* text, Fontinfo *info, bool flush_flag,
     }
 
     if ( info->isEndOfLine() ){
-        //info->newLine();
+        // Kunrakun: simple fix for overlapping csel dialogue (issue #83)
+        if (script_h.enc.getEncoding() == Encoding::CODE_CP932)
+            info->newLine();
+        else
+            //info->newLine();
+            ;
+        
         for (int i=0 ; i<indent_offset ; i++)
             if (script_h.enc.getEncoding() == Encoding::CODE_CP932) {
                 sentence_font.advanceCharInHankaku(2);

--- a/ONScripterLabel_text.cpp
+++ b/ONScripterLabel_text.cpp
@@ -295,7 +295,7 @@ void ONScripterLabel::drawChar( char* text, Fontinfo *info, bool flush_flag,
     }
 
     if ( info->isEndOfLine() ){
-        info->newLine();
+        //info->newLine();
         for (int i=0 ; i<indent_offset ; i++)
             if (script_h.enc.getEncoding() == Encoding::CODE_CP932) {
                 sentence_font.advanceCharInHankaku(2);


### PR DESCRIPTION
In UTF-8 mode, 
Selective sentences are output in a form that is difficult to see.

<img src="https://github.com/user-attachments/assets/6065ebca-58fd-4f6d-8452-863f9708b51f" width="700" height=auto />

I just annotated one line
`//info->newLine();`

And It works..
The function isEndOfLine() seems to be acting in a different way than intended in utf-8.

It has been tested only one specific case; pscript.dat

