### PR TITLE
fix to show appropriate numbers by adding a function

### DIFF
--- a/ONScripterLabel_command.cpp
+++ b/ONScripterLabel_command.cpp
@@ -1669,7 +1669,7 @@ int ONScripterLabel::prnumCommand()
 
     char num_buf[7];
     // Use fullwidth digits
-    script_h.getStringFromInteger( num_buf, prnum_info[no]->param, 3, false, true );
+    script_h.convertNumToFullWidthStr(prnum_info[no]->param, num_buf);
     setStr( &prnum_info[no]->file_name, num_buf );
 
     setupAnimationInfo( prnum_info[no] );

--- a/ONScripterLabel_text.cpp
+++ b/ONScripterLabel_text.cpp
@@ -295,7 +295,7 @@ void ONScripterLabel::drawChar( char* text, Fontinfo *info, bool flush_flag,
     }
 
     if ( info->isEndOfLine() ){
-        info->newLine();
+        //info->newLine();
         for (int i=0 ; i<indent_offset ; i++)
             if (script_h.enc.getEncoding() == Encoding::CODE_CP932) {
                 sentence_font.advanceCharInHankaku(2);

--- a/ScriptHandler.cpp
+++ b/ScriptHandler.cpp
@@ -1433,6 +1433,37 @@ void ScriptHandler::setNumVariable( int no, int val )
     vd.num = val;
 }
 
+void ScriptHandler::convertNumToFullWidthStr(int num, char* str) {
+    if (num < 0) {
+        strcat(str, "-");
+        num = -num;
+    }
+    while (num > 0) {
+        int digit = num % 10;
+        if (digit == 0)
+            strcat(str, "\xEF\xBC\x90");
+        if (digit == 1)
+            strcat(str, "\xEF\xBC\x91");
+        if (digit == 2)
+            strcat(str, "\xEF\xBC\x92");
+        if (digit == 3)
+            strcat(str, "\xEF\xBC\x93");
+        if (digit == 4)
+            strcat(str, "\xEF\xBC\x94");
+        if (digit == 5)
+            strcat(str, "\xEF\xBC\x95");
+        if (digit == 6)
+            strcat(str, "\xEF\xBC\x96");
+        if (digit == 7)
+            strcat(str, "\xEF\xBC\x97");
+        if (digit == 8)
+            strcat(str, "\xEF\xBC\x98");
+        if (digit == 9)
+            strcat(str, "\xEF\xBC\x99");
+        num /= 10;
+    }
+}
+
 int ScriptHandler::getStringFromInteger( char *buffer, int no, int num_column,
                                          bool is_zero_inserted,
                                          bool use_zenkaku )

--- a/ScriptHandler.h
+++ b/ScriptHandler.h
@@ -208,6 +208,7 @@ public:
 
     void setInt( VariableInfo *var_info, int val, int offset=0 );
     void setNumVariable( int no, int val );
+    void convertNumToFullWidthStr(int num, char* str);
     void pushVariable();
     int  getIntVariable( VariableInfo *var_info=NULL );
 


### PR DESCRIPTION
In UTF-8 mode,
`getStringFromInteger` seems to be acting in a different way than intended in utf-8.
I add a function `convertNumToFullWidthStr()` to convert numbers into full-width numbers and replace the `getStringFromInteger()`
It works

It has been tested only one specific case; pscript.dat