### PR TITLE
extlib/smpeg: remove the use of 'register' storage class specifier

### DIFF
--- a/extlib/src/smpeg/MPEG.cpp
+++ b/extlib/src/smpeg/MPEG.cpp
@@ -468,7 +468,7 @@ void MPEG::GetSystemInfo(MPEG_SystemInfo * sinfo)
 void MPEG::parse_stream_list()
 {
   MPEGstream ** stream_list;
-  register int i;
+  int i;
 
   /* A new thread is created for each video and audio */
   /* stream                                           */ 

--- a/extlib/src/smpeg/MPEGaudio.h
+++ b/extlib/src/smpeg/MPEGaudio.h
@@ -130,13 +130,13 @@ public:
   void rewind(int bits)  {bitindex-=bits;};
   void forward(int bits) {bitindex+=bits;};
   int getbit(void) {
-      register int r=(buffer[bitindex>>3]>>(7-(bitindex&7)))&1;
+      int r=(buffer[bitindex>>3]>>(7-(bitindex&7)))&1;
       bitindex++;
       return r;
   }
   int getbits9(int bits)
   {
-      register unsigned short a;
+      unsigned short a;
       { int offset=bitindex>>3;
 
         a=(((unsigned char)buffer[offset])<<8) | ((unsigned char)buffer[offset+1]);

--- a/extlib/src/smpeg/MPEGfilter.c
+++ b/extlib/src/smpeg/MPEGfilter.c
@@ -40,8 +40,8 @@ static void filter_destroy(SMPEG_Filter *filter)
 
 static void filter_null_callback(SDL_Overlay * dst, SDL_Overlay * src, SDL_Rect * region, SMPEG_FilterInfo * info, void * data)
 {
-  register Uint32 y;
-  register Uint8 * s, * d;
+  Uint32 y;
+  Uint8 * s, * d;
 
   /* Y component */
   s = src->pixels[0];
@@ -105,8 +105,8 @@ SMPEG_Filter *SMPEGfilter_null(void)
 
 static void filter_bilinear_callback(SDL_Overlay * dst, SDL_Overlay * src, SDL_Rect * region, SMPEG_FilterInfo * info, void * data)
 {
-  register int x, y;
-  register Uint8 * s, * d;
+  int x, y;
+  Uint8 * s, * d;
 
   s = src->pixels[0];
   d = dst->pixels[0];
@@ -200,7 +200,7 @@ static void filter_deblocking_callback(SDL_Overlay * dst, SDL_Overlay * src, SDL
   Uint32 aL, aU, aR, aD;
   Uint32 Q;
   Uint16 * coeffs;
-  register Uint8 * s, * d;
+  Uint8 * s, * d;
 
   /* retrieve the coeffs from private data */
   coeffs = (Uint16 *) data;

--- a/extlib/src/smpeg/MPEGsystem.cpp
+++ b/extlib/src/smpeg/MPEGsystem.cpp
@@ -709,8 +709,8 @@ header_size, packet_size, stream_id, stream_timestamp);
       else
       {
 	/* Check for next slice, picture, gop or sequence header */
-	register Uint8 * p;
-	register Uint8 c;
+	Uint8 * p;
+	Uint8 c;
 	
 	p = pointer + packet_size;
       state0:
@@ -890,8 +890,8 @@ void MPEGsystem::Skip(double time)
  
 Uint32 MPEGsystem::Tell()
 {
-  register Uint32 t;
-  register int i;
+  Uint32 t;
+  int i;
 
   /* Sum all stream positions */
   for(i = 0, t = 0; stream_list[i]; i++)
@@ -1354,7 +1354,7 @@ int MPEGsystem::SystemThread(void * udata)
 
 void MPEGsystem::add_stream(MPEGstream * stream)
 {
-  register int i;
+  int i;
 
   /* Go to the end of the list */
   for(i = 0; stream_list[i]; i++);
@@ -1372,7 +1372,7 @@ void MPEGsystem::add_stream(MPEGstream * stream)
 
 MPEGstream * MPEGsystem::get_stream(Uint8 stream_id)
 {
-  register int i;
+  int i;
 
   for(i = 0; stream_list[i]; i++)
     if(stream_list[i]->streamid == stream_id)
@@ -1383,7 +1383,7 @@ MPEGstream * MPEGsystem::get_stream(Uint8 stream_id)
 
 Uint8 MPEGsystem::exist_stream(Uint8 stream_id, Uint8 mask)
 {
-  register int i;
+  int i;
 
   for(i = 0; stream_list[i]; i++)
     if(((stream_list[i]->streamid) & mask) == (stream_id & mask))
@@ -1394,7 +1394,7 @@ Uint8 MPEGsystem::exist_stream(Uint8 stream_id, Uint8 mask)
 
 void MPEGsystem::reset_all_streams()
 {
-  register int i;
+  int i;
 
   /* Reset the streams */
   for(i = 0; stream_list[i]; i++)
@@ -1403,7 +1403,7 @@ void MPEGsystem::reset_all_streams()
 
 void MPEGsystem::end_all_streams()
 {
-  register int i;
+  int i;
 
   /* End the streams */
   /* We use a null buffer as the end of stream marker */

--- a/extlib/src/smpeg/audio/MPEGaudio.cpp
+++ b/extlib/src/smpeg/audio/MPEGaudio.cpp
@@ -324,7 +324,7 @@ MPEGaudio::getbyte(void)
 int 
 MPEGaudio::getbit(void) 
 {
-  register int r=(_buffer[bitindex>>3]>>(7-(bitindex&7)))&1;
+  int r=(_buffer[bitindex>>3]>>(7-(bitindex&7)))&1;
 
   bitindex++;
   return r;
@@ -333,7 +333,7 @@ MPEGaudio::getbit(void)
 int 
 MPEGaudio::getbits8(void) 
 {
-  register unsigned short a;
+  unsigned short a;
   { int offset=bitindex>>3;
 
   a=(((unsigned char)_buffer[offset])<<8) | ((unsigned char)_buffer[offset+1]);
@@ -346,7 +346,7 @@ MPEGaudio::getbits8(void)
 int 
 MPEGaudio::getbits9(int bits) 
 {
-  register unsigned short a;
+  unsigned short a;
   { int offset=bitindex>>3;
 
   a=(((unsigned char)_buffer[offset])<<8) | ((unsigned char)_buffer[offset+1]);

--- a/extlib/src/smpeg/audio/filter.cpp
+++ b/extlib/src/smpeg/audio/filter.cpp
@@ -25,7 +25,7 @@ void MPEGaudio::computebuffer(REAL *fraction,REAL buffer[2][CALCBUFFERSIZE])
 
   // compute new values via a fast cosine transform:
   {
-    register REAL *x=fraction;
+    REAL *x=fraction;
 
     p0=x[ 0]+x[31];p1=x[ 1]+x[30];p2=x[ 2]+x[29];p3=x[ 3]+x[28];
     p4=x[ 4]+x[27];p5=x[ 5]+x[26];p6=x[ 6]+x[25];p7=x[ 7]+x[24];
@@ -59,7 +59,7 @@ void MPEGaudio::computebuffer(REAL *fraction,REAL buffer[2][CALCBUFFERSIZE])
   pc=qc+qd;pd=hcos_4*(qc-qd);pe=qe+qf;pf=hcos_4*(qe-qf);
 
   {
-    register REAL tmp;
+    REAL tmp;
 
     tmp=p6+p7;
     OUT2(36)=-(p5+tmp);
@@ -84,7 +84,7 @@ void MPEGaudio::computebuffer(REAL *fraction,REAL buffer[2][CALCBUFFERSIZE])
   }
 
   {
-    register REAL *x=fraction;
+    REAL *x=fraction;
 
     p0=hcos_64[ 0]*(x[ 0]-x[31]);p1=hcos_64[ 1]*(x[ 1]-x[30]);
     p2=hcos_64[ 2]*(x[ 2]-x[29]);p3=hcos_64[ 3]*(x[ 3]-x[28]);
@@ -165,8 +165,8 @@ void MPEGaudio::computebuffer(REAL *fraction,REAL buffer[2][CALCBUFFERSIZE])
 void MPEGaudio::generatesingle(void)
 {
   int i;
-  register REAL r, *vp;
-  register const REAL *dp;
+  REAL r, *vp;
+  const REAL *dp;
   int raw;
 
   i=32;
@@ -251,8 +251,8 @@ void MPEGaudio::generate(void)
 {
   int i;
   REAL r1,r2;
-  register REAL *vp1,*vp2;
-  register const REAL *dp;
+  REAL *vp1,*vp2;
+  const REAL *dp;
   int raw;
 
   dp=filter;

--- a/extlib/src/smpeg/audio/filter_2.cpp
+++ b/extlib/src/smpeg/audio/filter_2.cpp
@@ -25,7 +25,7 @@ void MPEGaudio::computebuffer_2(REAL *fraction,REAL buffer[2][CALCBUFFERSIZE])
 
   // compute new values via a fast cosine transform:
   /*  {
-    register REAL *x=fraction;
+    REAL *x=fraction;
 
     p0=x[ 0]+x[31];p1=x[ 1]+x[30];p2=x[ 2]+x[29];p3=x[ 3]+x[28];
     p4=x[ 4]+x[27];p5=x[ 5]+x[26];p6=x[ 6]+x[25];p7=x[ 7]+x[24];
@@ -41,7 +41,7 @@ void MPEGaudio::computebuffer_2(REAL *fraction,REAL buffer[2][CALCBUFFERSIZE])
   qe=hcos_32[6]*(p6-p9);qf=hcos_32[7]*(p7-p8); */
 
   {
-    register REAL *x=fraction;
+    REAL *x=fraction;
 
     q0=x[ 0]+x[15];q1=x[ 1]+x[14];q2=x[ 2]+x[13];q3=x[ 3]+x[12];
     q4=x[ 4]+x[11];q5=x[ 5]+x[10];q6=x[ 6]+x[ 9];q7=x[ 7]+x[ 8];
@@ -70,7 +70,7 @@ void MPEGaudio::computebuffer_2(REAL *fraction,REAL buffer[2][CALCBUFFERSIZE])
   pc=qc+qd;pd=hcos_4*(qc-qd);pe=qe+qf;pf=hcos_4*(qe-qf);
 
   {
-    register REAL tmp;
+    REAL tmp;
 
     tmp=p6+p7;
     OUT2(36)=-(p5+tmp);
@@ -95,7 +95,7 @@ void MPEGaudio::computebuffer_2(REAL *fraction,REAL buffer[2][CALCBUFFERSIZE])
   }
 
   {
-    register REAL *x=fraction;
+    REAL *x=fraction;
 
     /*    p0=hcos_64[ 0]*(x[ 0]-x[31]);p1=hcos_64[ 1]*(x[ 1]-x[30]);
     p2=hcos_64[ 2]*(x[ 2]-x[29]);p3=hcos_64[ 3]*(x[ 3]-x[28]);
@@ -186,8 +186,8 @@ void MPEGaudio::computebuffer_2(REAL *fraction,REAL buffer[2][CALCBUFFERSIZE])
 void MPEGaudio::generatesingle_2(void)
 {
   int i;
-  register REAL r, *vp;
-  register const REAL *dp;
+  REAL r, *vp;
+  const REAL *dp;
   int raw;
 
   i=32/2;
@@ -273,8 +273,8 @@ void MPEGaudio::generate_2(void)
 {
   int i;
   REAL r1,r2;
-  register REAL *vp1,*vp2;
-  register const REAL *dp;
+  REAL *vp1,*vp2;
+  const REAL *dp;
   int raw;
 
   dp=filter;

--- a/extlib/src/smpeg/audio/mpeglayer1.cpp
+++ b/extlib/src/smpeg/audio/mpeglayer1.cpp
@@ -49,7 +49,7 @@ void MPEGaudio::extractlayer1(void)
   int bitalloc[MAXCHANNEL][MAXSUBBAND],
       sample[MAXCHANNEL][MAXSUBBAND];
 
-  register int i,j;
+  int i,j;
   int s=stereobound,l;
 
 

--- a/extlib/src/smpeg/audio/mpeglayer2.cpp
+++ b/extlib/src/smpeg/audio/mpeglayer2.cpp
@@ -433,8 +433,8 @@ void MPEGaudio::extractlayer2(void)
 
 // Bitalloc
   {
-    register int i;
-    register const int *t=bitalloclengthtable[tableindex];
+    int i;
+    const int *t=bitalloclengthtable[tableindex];
 
     for(i=0;i<s;i++,t++)
     {
@@ -448,18 +448,18 @@ void MPEGaudio::extractlayer2(void)
 
   // Scale selector
   if(inputstereo)
-    for(register int i=0;i<n;i++)
+    for(int i=0;i<n;i++)
     {
       if(bitalloc[LS][i])scaleselector[LS][i]=getbits(2);
       if(bitalloc[RS][i])scaleselector[RS][i]=getbits(2);
     }
   else
-    for(register int i=0;i<n;i++)
+    for(int i=0;i<n;i++)
       if(bitalloc[LS][i])scaleselector[LS][i]=getbits(2);
 
   // Scale index
   {
-    register int i,j;
+    int i,j;
 
     for(i=0;i<n;i++)
     {
@@ -604,7 +604,7 @@ void MPEGaudio::extractlayer2(void)
 
 // Read Sample
   {
-    register int i;
+    int i;
 
     for(int l=0;l<SCALEBLOCK;l++)
     {
@@ -615,7 +615,7 @@ void MPEGaudio::extractlayer2(void)
 	{
 	  if(group[LS][i])
 	  {
-	    register const REAL *s;
+	    const REAL *s;
 	    int code=getbits(codelength[LS][i]);
 
 	    code+=code<<1;
@@ -678,7 +678,7 @@ void MPEGaudio::extractlayer2(void)
 	{
 	  if(group[LS][i])
 	  {
-	    register const REAL *s;
+	    const REAL *s;
 	    int code=getbits(codelength[LS][i]);
 
 	    code+=code<<1;
@@ -717,7 +717,7 @@ void MPEGaudio::extractlayer2(void)
 	      fraction[LS][2][i]=(fraction[LS][2][i]+d[LS][i])*c[LS][i];
 	    }
 
-	    register REAL t=scalefactor[LS][l>>2][i];
+	    REAL t=scalefactor[LS][l>>2][i];
 	    fraction[LS][0][i]*=t;
 	    fraction[LS][1][i]*=t;
 	    fraction[LS][2][i]*=t;
@@ -732,7 +732,7 @@ void MPEGaudio::extractlayer2(void)
 	      fraction[RS][2][i]=(fraction[RS][2][i]+d[RS][i])*c[RS][i];
 	    }
 
-	    register REAL t=scalefactor[RS][l>>2][i];
+	    REAL t=scalefactor[RS][l>>2][i];
 	    fraction[RS][0][i]*=t;
 	    fraction[RS][1][i]*=t;
 	    fraction[RS][2][i]*=t;
@@ -749,7 +749,7 @@ void MPEGaudio::extractlayer2(void)
 	      fraction[LS][2][i]=(fraction[LS][2][i]+d[LS][i])*c[LS][i];
 	    }
 
-	    register REAL t=scalefactor[LS][l>>2][i];
+	    REAL t=scalefactor[LS][l>>2][i];
 	    fraction[LS][0][i]*=t;
 	    fraction[LS][1][i]*=t;
 	    fraction[LS][2][i]*=t;

--- a/extlib/src/smpeg/audio/mpeglayer3.cpp
+++ b/extlib/src/smpeg/audio/mpeglayer3.cpp
@@ -31,7 +31,7 @@ inline void Mpegbitwindow::wrap(void)
 
   if(p>=point)
   {
-    for(register int i=4;i<point;i++)
+    for(int i=4;i<point;i++)
       buffer[WINDOWSIZE+i]=buffer[i];
   }
   *((int *)(buffer+WINDOWSIZE))=*((int *)buffer);
@@ -92,7 +92,7 @@ static RATIOS rat_1[16],rat_2[2][64];
 void MPEGaudio::layer3initialize(void)
 {
   static bool initializedlayer3=false;
-  register int i;
+  int i;
   int j,k,l;
 #if 0
 	double td = 0.0;
@@ -353,7 +353,7 @@ void MPEGaudio::layer3getscalefactors(int ch,int gr)
 			  {0, 1, 2, 3, 0, 1, 2, 3, 1, 2, 3, 1, 2, 3, 2, 3}};
 
   layer3grinfo *gi=&(sideinfo.ch[ch].gr[gr]);
-  register layer3scalefactor *sf=(&scalefactors[ch]);
+  layer3scalefactor *sf=(&scalefactors[ch]);
   int l0,l1;
 
   {
@@ -486,7 +486,7 @@ void MPEGaudio::layer3getscalefactors_2(int ch)
 
   int sb[54];
   layer3grinfo *gi=&(sideinfo.ch[ch].gr[0]);
-  register layer3scalefactor *sf=(&scalefactors[ch]);
+  layer3scalefactor *sf=(&scalefactors[ch]);
 
   {
     int blocktypenumber,sc;
@@ -648,7 +648,7 @@ void MPEGaudio::huffmandecoder_1(const HUFFMANCODETABLE *h,int *x,int *y)
     level>>=1;
     if(!(level || ((unsigned)point<ht->treelen)))
     {
-      register int xx,yy;
+      int xx,yy;
 
       xx=(h->xlen<<1);// set x and y to a medium value as a simple concealment
       yy=(h->ylen<<1);
@@ -677,7 +677,7 @@ void MPEGaudio::huffmandecoder_2(const HUFFMANCODETABLE *h,
   {
     if(h->val[point][0]==0)
     {   /*end of tree*/
-      register int t=h->val[point][1];
+      int t=h->val[point][1];
 
       if(t&8)*v=1-(wgetbit()<<1); else *v=0;
       if(t&4)*w=1-(wgetbit()<<1); else *w=0;
@@ -749,7 +749,7 @@ void MPEGaudio::layer3huffmandecode(int ch,int gr,int out[SBLIMIT][SSLIMIT])
   for(i=0;i<e;)
   {
     const HUFFMANCODETABLE *h;
-    register int end;
+    int end;
       
     if     (i<region1Start)
     {
@@ -855,10 +855,10 @@ void MPEGaudio::layer3dequantizesample(int ch,int gr,
     {
       cb_width=(sfBandIndex->s[cb+1]-sfBandIndex->s[cb])>>1;
 
-      for(register int k=0;k<3;k++)
+      for(int k=0;k<3;k++)
       {
-	register REAL factor;
-	register int count=cb_width;
+	REAL factor;
+	int count=cb_width;
 
 	factor=globalgain*
 	       layer3twopow2_1(gi->subblock_gain[k],gi->scalefac_scale,
@@ -1216,7 +1216,7 @@ void MPEGaudio::layer3fixtostereo(int gr,REAL in[2][SBLIMIT][SSLIMIT])
       do{
 	if(is_pos[i]==7)
 	{
-	  register REAL t=in[LS][0][i];
+	  REAL t=in[LS][0][i];
 	  in[LS][0][i]=(t+in[RS][0][i])*0.7071068f;
 	  in[RS][0][i]=(t-in[RS][0][i])*0.7071068f;
 	}
@@ -1245,7 +1245,7 @@ void MPEGaudio::layer3fixtostereo(int gr,REAL in[2][SBLIMIT][SSLIMIT])
     {
       int i=ARRAYSIZE-1;
       do{
-	register REAL t=in[LS][0][i];
+	REAL t=in[LS][0][i];
 
 	in[LS][0][i]=(t+in[RS][0][i])*0.7071068f;
 	in[RS][0][i]=(t-in[RS][0][i])*0.7071068f;
@@ -1373,7 +1373,7 @@ void MPEGaudio::layer3reorderandantialias(int ch,int gr,
 					  REAL  in[SBLIMIT][SSLIMIT],
 					  REAL out[SBLIMIT][SSLIMIT])
 {
-  register layer3grinfo *gi=&(sideinfo.ch[ch].gr[gr]);
+  layer3grinfo *gi=&(sideinfo.ch[ch].gr[gr]);
 
   if(gi->generalflag)
   {
@@ -1411,7 +1411,7 @@ static void dct36(REAL *inbuf,REAL *prevblk1,REAL *prevblk2,REAL *wi,REAL *out)
     MACRO0(v); }
 
   {
-    register REAL *in = inbuf;
+    REAL *in = inbuf;
    
     in[17]+=in[16];in[16]+=in[15];in[15]+=in[14];in[14]+=in[13]; 
     in[13]+=in[12];in[12]+=in[11];in[11]+=in[10];in[10]+=in[ 9];
@@ -1423,10 +1423,10 @@ static void dct36(REAL *inbuf,REAL *prevblk1,REAL *prevblk2,REAL *wi,REAL *out)
     in[ 9]+=in[ 7];in[7] +=in[ 5];in[ 5]+=in[ 3];in[ 3]+=in[ 1];
 
     {
-      register REAL *c = cos_18;
-      register REAL *out2 = prevblk2;
-      register REAL *out1 = prevblk1;
-      register REAL *ts = out;
+      REAL *c = cos_18;
+      REAL *out2 = prevblk2;
+      REAL *out1 = prevblk1;
+      REAL *ts = out;
       
       REAL ta33,ta66,tb33,tb66;
 
@@ -1486,7 +1486,7 @@ static void dct36(REAL *inbuf,REAL *prevblk1,REAL *prevblk2,REAL *wi,REAL *out)
 }
 
 
-static void dct12(REAL *in,REAL *prevblk1,REAL *prevblk2,register REAL *wi,register REAL *out)
+static void dct12(REAL *in,REAL *prevblk1,REAL *prevblk2,REAL *wi,REAL *out)
 {
 #define DCT12_PART1   \
         in5=in[5*3];  \
@@ -1520,7 +1520,7 @@ static void dct12(REAL *in,REAL *prevblk1,REAL *prevblk2,register REAL *wi,regis
 
   {
     REAL in0,in1,in2,in3,in4,in5;
-    register REAL *pb1=prevblk1;
+    REAL *pb1=prevblk1;
     out[SBLIMIT*0]=pb1[0];out[SBLIMIT*1]=pb1[1];out[SBLIMIT*2]=pb1[2];
     out[SBLIMIT*3]=pb1[3];out[SBLIMIT*4]=pb1[4];out[SBLIMIT*5]=pb1[5];
  
@@ -1529,7 +1529,7 @@ static void dct12(REAL *in,REAL *prevblk1,REAL *prevblk2,register REAL *wi,regis
     {
       REAL tmp0,tmp1=(in0-in4);
       {
-	register REAL tmp2=(in1-in5)*hsec_12[1];
+	REAL tmp2=(in1-in5)*hsec_12[1];
 	tmp0=tmp1+tmp2;
 	tmp1-=tmp2;
       }
@@ -1554,7 +1554,7 @@ static void dct12(REAL *in,REAL *prevblk1,REAL *prevblk2,register REAL *wi,regis
   in++;
   {
     REAL in0,in1,in2,in3,in4,in5;
-    register REAL *pb2 = prevblk2;
+    REAL *pb2 = prevblk2;
  
     DCT12_PART1;
 
@@ -1587,7 +1587,7 @@ static void dct12(REAL *in,REAL *prevblk1,REAL *prevblk2,register REAL *wi,regis
   in++; 
   {
     REAL in0,in1,in2,in3,in4,in5;
-    register REAL *pb2 = prevblk2;
+    REAL *pb2 = prevblk2;
     pb2[12]=pb2[13]=pb2[14]=pb2[15]=pb2[16]=pb2[17]=0.0;
 
     DCT12_PART1;
@@ -1692,12 +1692,12 @@ void MPEGaudio::extractlayer3(void)
 	 
     if(issync())
     {
-      for(register int i=layer3slots;i>0;i--)  // read main data.
+      for(int i=layer3slots;i>0;i--)  // read main data.
 	bitwindow.putbyte(getbyte());
     }
     else
     {
-      for(register int i=layer3slots;i>0;i--)  // read main data.
+      for(int i=layer3slots;i>0;i--)  // read main data.
 	bitwindow.putbyte(getbits8());
     }
 
@@ -1765,7 +1765,7 @@ void MPEGaudio::extractlayer3(void)
       layer3reorderandantialias(RS,gr,b2.lr[RS],b1.hin[RS]);
       layer3hybrid (RS,gr,b1.hin[RS],b2.hout[RS]);
 
-      register int i=2*SSLIMIT*SBLIMIT-1;
+      int i=2*SSLIMIT*SBLIMIT-1;
       do{
 	NEG(b2.hout[0][0][i   ]);NEG(b2.hout[0][0][i- 2]);
 	NEG(b2.hout[0][0][i- 4]);NEG(b2.hout[0][0][i- 6]);
@@ -1779,7 +1779,7 @@ void MPEGaudio::extractlayer3(void)
     }
     else
     {
-      register int i=SSLIMIT*SBLIMIT-1;
+      int i=SSLIMIT*SBLIMIT-1;
       do{
 	NEG(b2.hout[0][0][i   ]);NEG(b2.hout[0][0][i- 2]);
 	NEG(b2.hout[0][0][i- 4]);NEG(b2.hout[0][0][i- 6]);
@@ -1807,12 +1807,12 @@ void MPEGaudio::extractlayer3_2(void)
 	 
     if(issync())
     {
-      for(register int i=layer3slots;i>0;i--)  // read main data.
+      for(int i=layer3slots;i>0;i--)  // read main data.
 	bitwindow.putbyte(getbyte());
     }
     else
     {
-      for(register int i=layer3slots;i>0;i--)  // read main data.
+      for(int i=layer3slots;i>0;i--)  // read main data.
 	bitwindow.putbyte(getbits8());
     }
     bitwindow.wrap();
@@ -1875,7 +1875,7 @@ void MPEGaudio::extractlayer3_2(void)
       layer3reorderandantialias(RS,0,b2.lr[RS],b1.hin[RS]);
       layer3hybrid (RS,0,b1.hin[RS],b2.hout[RS]);
 
-      register int i=2*SSLIMIT*SBLIMIT-1;
+      int i=2*SSLIMIT*SBLIMIT-1;
       do{
 	NEG(b2.hout[0][0][i-16]);NEG(b2.hout[0][0][i-18]);
 	NEG(b2.hout[0][0][i-20]);NEG(b2.hout[0][0][i-22]);
@@ -1885,7 +1885,7 @@ void MPEGaudio::extractlayer3_2(void)
     }
     else
     {
-      register int i=SSLIMIT*SBLIMIT-1;
+      int i=SSLIMIT*SBLIMIT-1;
       do{
 	NEG(b2.hout[0][0][i-16]);NEG(b2.hout[0][0][i-18]);
 	NEG(b2.hout[0][0][i-20]);NEG(b2.hout[0][0][i-22]);

--- a/extlib/src/smpeg/audio/mpegtoraw.cpp
+++ b/extlib/src/smpeg/audio/mpegtoraw.cpp
@@ -80,8 +80,8 @@ void MPEGaudio::initialize()
 {
   static bool initialized = false;
 
-  register int i;
-  register REAL *s1,*s2;
+  int i;
+  REAL *s1,*s2;
   REAL *s3,*s4;
 
   last_speed = 0;
@@ -132,7 +132,7 @@ void MPEGaudio::initialize()
 
 bool MPEGaudio::loadheader()
 {
-    register int c;
+    int c;
     bool flag;
 
     flag = false;

--- a/extlib/src/smpeg/video/gdith.cpp
+++ b/extlib/src/smpeg/video/gdith.cpp
@@ -300,8 +300,8 @@ void MPEGvideo::DisplayFrame( VidStream * vid_stream )
   /* Compute additionnal info for the filter */
   if((_filter->flags & SMPEG_FILTER_INFO_PIXEL_ERROR) && vid_stream->current->mb_qscale)
   {
-    register int x, y;
-    register Uint16 * ptr;
+    int x, y;
+    Uint16 * ptr;
 
     /* Compute quantization error for each pixel */
     info.yuv_pixel_square_error = (Uint16 *) malloc(_w*_h*12/8*sizeof(Uint16));

--- a/extlib/src/smpeg/video/jrevdct.cpp
+++ b/extlib/src/smpeg/video/jrevdct.cpp
@@ -209,12 +209,12 @@ void init_pre_idct()
 void j_rev_dct_sparse( DCTBLOCK data, int pos )
 {
   short int val;
-  register int *dp;
-  register int v;
+  int *dp;
+  int v;
   int quant;
 
 #ifdef SPARSE_AC
-  register DCTELEM *dataptr;
+  DCTELEM *dataptr;
   DCTELEM *ndataptr;
   int coeff, rr;
   DCTBLOCK tmpdata, tmp2data;
@@ -390,7 +390,7 @@ void j_rev_dct( DCTBLOCK data )
   INT32 tmp10, tmp11, tmp12, tmp13;
   INT32 z1, z2, z3, z4, z5;
   INT32 d0, d1, d2, d3, d4, d5, d6, d7;
-  register DCTELEM *dataptr;
+  DCTELEM *dataptr;
   int rowctr;
   SHIFT_TEMPS
    
@@ -410,7 +410,7 @@ void j_rev_dct( DCTBLOCK data )
      * row DCT calculations can be simplified this way.
      */
 
-    register int *idataptr = (int*)dataptr;
+    int *idataptr = (int*)dataptr;
     d0 = dataptr[0];
     d1 = dataptr[1];
     if ((d1 == 0) && (idataptr[1] | idataptr[2] | idataptr[3]) == 0) {
@@ -418,7 +418,7 @@ void j_rev_dct( DCTBLOCK data )
       if (d0) {
 	  /* Compute a 32 bit value to assign. */
 	  DCTELEM dcval = (DCTELEM) (d0 << PASS1_BITS);
-	  register int v = (dcval & 0xffff) | (dcval << 16);
+	  int v = (dcval & 0xffff) | (dcval << 16);
 	  
 	  idataptr[0] = v;
 	  idataptr[1] = v;
@@ -1403,7 +1403,7 @@ void j_rev_dct( DCTBLOCK data )
   INT32 tmp0, tmp1, tmp2, tmp3;
   INT32 tmp10, tmp11, tmp12, tmp13;
   INT32 z1, z2, z3, z4, z5;
-  register DCTELEM *dataptr;
+  DCTELEM *dataptr;
   int rowctr;
   SHIFT_TEMPS
 

--- a/extlib/src/smpeg/video/vhar128.cpp
+++ b/extlib/src/smpeg/video/vhar128.cpp
@@ -148,7 +148,7 @@ void vhar128_destroyimage(unsigned int handle, struct vhar128_image * image)
 int vhar128_init(unsigned int handle, unsigned long width, unsigned long height, struct vhar128_image *ring[], int ring_size)
 {
     VHA_INIT vhaInit;
-    register int i;
+    int i;
 
     memset(&vhaInit, 0, sizeof(VHA_INIT));
 


### PR DESCRIPTION
It has always been intended as a hint to the compiler, however as of the ratification of the C++17 standard it is no longer permitted.