### PR TITLE
extlib/smpeg: hufftable narrowing conversion fix

### DIFF
--- a/Makefile.extlibs
+++ b/Makefile.extlibs
@@ -229,7 +229,6 @@ $(SMPGSRC)/Makefile: $(if $(INTERNAL_SDL),$(EB)/sdl-config)
 	./configure --prefix="$(LPREFIX)" $(OTHERCONFIG) \
 	    $(addprefix --disable-,shared gtk-player opengl-player $(SMPEG_DEBUG)) \
 	    $(REDIR)
-	@sed -i '/hufftable\.lo: audio\/hufftable\.cpp/{n;s/$$(CXXFLAGS)/$$(CXXFLAGS) -Wno-narrowing/}' $(SMPGSRC)/Makefile # Fix for unnecessary error -Galladite 2023-2-9
 
 $(EB)/smpeg-config: $(SMPGSRC)/Makefile | $(EB)
 	@echo Building internal smpeg...

--- a/extlib/src/smpeg/audio/hufftable.cpp
+++ b/extlib/src/smpeg/audio/hufftable.cpp
@@ -548,13 +548,15 @@ htd33[ 31][2]={{ 16,  1},{  8,  1},{  4,  1},{  2,  1},{  0,  0},{  0,  1},
 	       {  4,  1},{  2,  1},{  0, 12},{  0, 13},{  2,  1},{  0, 14},
 	       {  0, 15}};
 
+#define NEGATIVE_ONE static_cast<unsigned>(-1)
+
 const HUFFMANCODETABLE MPEGaudio::ht[HTN]=
 {
-  { 0, 0-1, 0-1, 0,  0, htd33},
+  { 0, NEGATIVE_ONE, NEGATIVE_ONE, 0,  0, htd33},
   { 1, 2-1, 2-1, 0,  7,htd01},
   { 2, 3-1, 3-1, 0, 17,htd02},
   { 3, 3-1, 3-1, 0, 17,htd03},
-  { 4, 0-1, 0-1, 0,  0, htd33},
+  { 4, NEGATIVE_ONE, NEGATIVE_ONE, 0,  0, htd33},
   { 5, 4-1, 4-1, 0, 31,htd05},
   { 6, 4-1, 4-1, 0, 31,htd06},
   { 7, 6-1, 6-1, 0, 71,htd07},
@@ -564,7 +566,7 @@ const HUFFMANCODETABLE MPEGaudio::ht[HTN]=
   {11, 8-1, 8-1, 0,127,htd11},
   {12, 8-1, 8-1, 0,127,htd12},
   {13,16-1,16-1, 0,511,htd13},
-  {14, 0-1, 0-1, 0,  0, htd33},
+  {14, NEGATIVE_ONE, NEGATIVE_ONE, 0,  0, htd33},
   {15,16-1,16-1, 0,511,htd15},
   {16,16-1,16-1, 1,511,htd16},
   {17,16-1,16-1, 2,511,htd16},


### PR DESCRIPTION
The proper fix for a "narrowing conversion" warning/error it to be explicit about it using `static_cast`.