### PR TITLE
Off-by-one error when computing the game_identifier size

### DIFF
--- a/ScriptHandler.cpp
+++ b/ScriptHandler.cpp
@@ -1887,9 +1887,8 @@ int ScriptHandler::readScript( DirPaths &path )
             }
         }
         else if ( tokenMatch( &buf, ";gameid " ) && !game_identifier ){
-            int i = 0;
-            while ( buf[++i] != '\n' );
-            game_identifier = new char[i];
+            int i = strcspn(buf, "\n");
+            game_identifier = new char[i + 1];
             strncpy( game_identifier, buf, i );
             game_identifier[i] = 0;
             buf += i;


### PR DESCRIPTION
When running under the debugger with extra checks enabled, I hit a heap check routine that spotted it. Seems back when I was refactoring this stuff, I introduced an off-by-one error here resulting in writing just over the edge of our buffer.  Fixed the off-by-one and replaced the loop with an appropriate C library function.